### PR TITLE
dial_plan.rb does not close File after read.

### DIFF
--- a/lib/adhearsion/voip/dial_plan.rb
+++ b/lib/adhearsion/voip/dial_plan.rb
@@ -201,6 +201,7 @@ module Adhearsion
       def load(dialplan_file)
         dialplan_code = dialplan_file.read
         @context_collector.instance_eval(dialplan_code, dialplan_file.path)
+        dialplan_file.close
         nil
       end
 


### PR DESCRIPTION
This results on a file descriptor leak on every call.
