### PR TITLE
Updates for QueueProxy#join!

### DIFF
--- a/lib/adhearsion/voip/asterisk/commands.rb
+++ b/lib/adhearsion/voip/asterisk/commands.rb
@@ -1244,23 +1244,24 @@ module Adhearsion
             #
             # According to http://www.voip-info.org/wiki/view/Asterisk+cmd+Queue
             # possible values are:
-            # TIMEOUT (:timeout
-            # FULL (:full)
-            # JOINEMPTY (:joinempty)
-            # LEAVEEMPTY (:leaveempty)
-            # JOINUNAVAIL (:joinunavail)
-            # LEAVEUNAVAIL (:leaveunavail)
             #
-            # If Adhearsion cannot determine the status then :unknown will be returned.
+            # TIMEOUT      => :timeout
+            # FULL         => :full
+            # JOINEMPTY    => :joinempty
+            # LEAVEEMPTY   => :leaveempty
+            # JOINUNAVAIL  => :joinunavail
+            # LEAVEUNAVAIL => :leaveunavail
+            # CONTINUE     => :continue
+            #
+            # If the QUEUESTATUS variable is not set the call was successfully connected, 
+            # and Adhearsion will return :completed.
             #
             # @param [String] QUEUESTATUS variable from Asterisk
             # @return [Symbol] Symbolized version of QUEUESTATUS
             # @raise QueueDoesNotExistError
             def normalize_queue_status_variable(variable)
-              variable = "UNKNOWN" if variable.nil?
-              variable.downcase.to_sym.tap do |queue_status|
-                raise QueueDoesNotExistError.new(name) if queue_status == :unknown
-              end
+              variable = "COMPLETED" if variable.nil?
+              variable.downcase.to_sym
             end
 
             class QueueAgentsListProxy

--- a/spec/voip/asterisk/test_commands.rb
+++ b/spec/voip/asterisk/test_commands.rb
@@ -525,6 +525,12 @@ context "The queue management abstractions" do
     mock_call.queue('monkey').join!.should.equal :timeout
   end
 
+  test 'should return :completed after joining the queue and being connected' do
+    does_not_read_data_back
+    mock_call.should_receive(:get_variable).once.with("QUEUESTATUS").and_return nil
+    mock_call.queue('monkey').join!.should.equal :completed
+  end
+
   test 'should join a queue with a timeout properly' do
     mock_call.should_receive(:execute).once.with("queue", "foobaz", "", '', '', '60', '')
     mock_call.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"


### PR DESCRIPTION
- Returns :completed if QUEUESTATUS was not set.
- Supports AGI parameter.
- Fixed test for specifying an announcement file.

(tested against Asterisk 1.4.22 with jRuby 1.5.6)
