### PR TITLE
Update QueueAgentsListProxy#new and its associated tests.

### DIFF
--- a/lib/adhearsion/voip/asterisk/commands.rb
+++ b/lib/adhearsion/voip/asterisk/commands.rb
@@ -1290,8 +1290,9 @@ module Adhearsion
               def new(*args)
 
                 options   = args.last.kind_of?(Hash) ? args.pop : {}
-                interface = args.shift || ''
+                interface = args.shift
 
+                raise ArgumentError, "You must specify an interface to add." if interface.nil?
                 raise ArgumentError, "You may only supply an interface and a Hash argument!" if args.any?
 
                 penalty             = options.delete(:penalty)            || ''

--- a/spec/voip/asterisk/test_commands.rb
+++ b/spec/voip/asterisk/test_commands.rb
@@ -705,26 +705,26 @@ context "The queue management abstractions" do
 
   test 'should execute AddQueueMember with the penalty properly' do
     queue_name = 'name_does_not_matter'
-    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, '', 10, '', '','')
+    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, 'Agent/007', 10, '', '','')
     mock_call.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
     mock_call.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
-    mock_call.queue(queue_name).agents.new :penalty => 10
+    mock_call.queue(queue_name).agents.new 'Agent/007', :penalty => 10
   end
 
   test 'should execute AddQueueMember with the state_interface properly' do
     queue_name = 'name_does_not_matter'
-    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, '', '', '', '','SIP/2302')
+    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, 'Agent/007', '', '', '','SIP/2302')
     mock_call.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
     mock_call.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
-    mock_call.queue(queue_name).agents.new :state_interface => 'SIP/2302'
+    mock_call.queue(queue_name).agents.new 'Agent/007', :state_interface => 'SIP/2302'
   end
 
   test 'should execute AddQueueMember properly when the name is given' do
     queue_name, agent_name = 'name_does_not_matter', 'Jay Phillips'
-    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, '', '', '', agent_name,'')
+    mock_call.should_receive(:execute).once.with('AddQueueMember', queue_name, 'Agents/007', '', '', agent_name,'')
     mock_call.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
     mock_call.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
-    mock_call.queue(queue_name).agents.new :name => agent_name
+    mock_call.queue(queue_name).agents.new 'Agents/007', :name => agent_name
   end
 
   test 'should execute AddQueueMember properly when the name, penalty, and interface is given' do


### PR DESCRIPTION
- Add state_interface to QueueAgentsListProxy#new. - The state_interface parameter was added in Asterisk 1.6 and exists in 1.8.
- Require interface to be specified when calling QueueAgentsListProxy#new.

FYI - Tested on Asterisk 1.4.22 and verified that it doesn't cause errors.
