### PR TITLE
Rake is required by lib/adhearsion/tasks.rb. 

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -150,6 +150,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency("bundler", [">= 1.0.10"])
       s.add_runtime_dependency("log4r", [">= 1.0.5"])
       s.add_runtime_dependency("activesupport", [">= 2.1.0"])
+      s.add_runtime_dependency("rake")
       # i18n is only strictly a dependency for ActiveSupport >= 3.0.0
       # Since it doesn't conflict with <3.0.0 we'll require it to be
       # on the safe side.
@@ -165,10 +166,12 @@ Gem::Specification.new do |s|
       s.add_dependency("bundler", [">= 1.0.10"])
       s.add_dependency("log4r", [">= 1.0.5"])
       s.add_dependency("activesupport", [">= 2.1.0"])
+      s.add_dependency("rake")
     end
   else
     s.add_dependency("bundler", [">= 1.0.10"])
     s.add_dependency("log4r", [">= 1.0.5"])
     s.add_dependency("activesupport", [">= 2.1.0"])
+    s.add_dependency("rake")
   end
 end


### PR DESCRIPTION
Line 1 of tasks.rb requires 'rake/testtask' yet rake isn't defined as a dependency in the gemspec.  This results in the error 'Cannot load Adhearsion! Not all Rake tasks will be loaded!' when you run 'rake -T' in an adhearsion project.
