### PR TITLE
Fixing link to Ben Langfeld in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,7 +59,7 @@ Original author: [Jay Phillips](https://github.com/jicksta)
 Core team:
 
 * [Ben Klang](https://github.com/bklang)
-* [Ben Langfeld](https://github.com/blangfeld)
+* [Ben Langfeld](https://github.com/benlangfeld)
 * [Jason Goecke](https://github.com/jsgoecke)
 
 Contributors: https://github.com/adhearsion/adhearsion/contributors


### PR DESCRIPTION
A silly tweak to the 2.x README... I just noticed that Ben's URL wasn't working.

All other URLs in [README.markdown](https://github.com/adhearsion/adhearsion) appear to work as expected.

The only remaining oddities I noticed were in the new [CHANGELOG.md](https://github.com/adhearsion/adhearsion/blob/develop/CHANGELOG.md) -  http://adhearsion.com/style-guide and http://adhearsion.com/contribute send you to the Adhearsion homepage. However, both pages are currently TODO items (which is why I did not change them).

I think the current content for those pages lives at https://github.com/adhearsion/adhearsion/wiki/Documentation-Guidelines and https://github.com/adhearsion/adhearsion/wiki/Contributing, respectively.
