### PR TITLE
Support/1.x.x

### DIFF
--- a/lib/adhearsion/component_manager.rb
+++ b/lib/adhearsion/component_manager.rb
@@ -76,6 +76,11 @@ module Adhearsion
           return YAML.load_file "#{AHN_ROOT}/config/components/#{component_name}.yml"
         end
 
+        # Look for configuration in #{AHN_ROOT}/components/#{component_name}/config next
+        if File.exists?("#{AHN_ROOT}/components/#{component_name}/config/#{component_name}.yml")
+          return YAML.load_file "#{AHN_ROOT}/components/#{component_name}/config/#{component_name}.yml"
+        end
+
         # Next try the local app component directory
         component_dir = File.join(@path_to_container_directory, component_name)
         config_file = File.join component_dir, "#{component_name}.yml"


### PR DESCRIPTION
This fixes #83
The file that is created by the generator since commit
4aaf191ee85b9c7f4bc70d0d7eff1198553657f5 is not loaded automatically.
