### PR TITLE
config.punchblock.port doesn't have a default value

### DIFF
--- a/lib/adhearsion/punchblock_plugin.rb
+++ b/lib/adhearsion/punchblock_plugin.rb
@@ -15,7 +15,7 @@ module Adhearsion
       username            "usera@127.0.0.1", :desc => "Authentication credentials"
       password            "1"              , :desc => "Authentication credentials"
       host                nil              , :desc => "Host punchblock needs to connect (where rayo or asterisk are located)"
-      port                nil              , :transform => Proc.new { |v| PunchblockPlugin.validate_number v }, :desc => "Port punchblock needs to connect (by default 5038 for Asterisk, 5222 for Rayo)"
+      port                Proc.new { PunchblockPlugin.default_port_for_platform platform }, :transform => Proc.new { |v| PunchblockPlugin.validate_number v }, :desc => "Port punchblock needs to connect (by default 5038 for Asterisk, 5222 for Rayo)"
       root_domain         nil              , :desc => "The root domain at which to address the server"
       calls_domain        nil              , :desc => "The domain at which to address calls"
       mixers_domain       nil              , :desc => "The domain at which to address mixers"
@@ -40,6 +40,14 @@ module Adhearsion
       def validate_number(value)
         return 1.0/0.0 if ["Infinity", 1.0/0.0].include? value
         value.to_i
+      end
+
+      def default_port_for_platform(platform)
+        case platform
+          when :asterisk then 5038
+          when :xmpp then 5222
+          else nil
+        end
       end
 
       def execute_component(command, timeout = 60)


### PR DESCRIPTION
``` ruby
  # Port punchblock needs to connect (by default 5038 for Asterisk, 5222 for Rayo) [AHN_PUNCHBLOCK_PORT]
  config.punchblock.port               = nil
```

It reads to me like Punchblock will connect to port 5038 by default when the Asterisk platform is selected and will default to 5222 for Rayo.
But what happens is Punchblock will try to connect with the port set to nil, causing it to lock up.

This should probably throw an error and preferably use the default port (5038 if the platform is set to Asterisk).
