### PR TITLE
[BUGFIX] #record timeouts are now in seconds instead of ms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/adhearsion)
   * Bugfix: Output controller methods no longer falsely detect a string with a colon as a URI for an audio file
+  * Bugfix: #record now accepts timeout in seconds instead of milliseconds
 
 # [2.1.2](https://github.com/adhearsion/adhearsion/compare/v2.1.1...v2.1.2) - [2012-09-16](https://rubygems.org/gems/adhearsion/versions/2.1.2)
   * Bugfix: Celluloid 0.12.x dependency now disallowed due to incompatible API changes.

--- a/lib/adhearsion/call_controller/record.rb
+++ b/lib/adhearsion/call_controller/record.rb
@@ -21,11 +21,11 @@ module Adhearsion
       # @option options [Boolean, Optional] :async Execute asynchronously. Defaults to false
       # @option options [Boolean, Optional] :start_beep Indicates whether subsequent record will be preceded with a beep. Default is true.
       # @option options [Boolean, Optional] :start_paused Whether subsequent record will start in PAUSE mode. Default is false.
-      # @option options [String, Optional] :max_duration Indicates the maximum duration (milliseconds) for a recording.
+      # @option options [String, Optional] :max_duration Indicates the maximum duration (seconds) for a recording.
       # @option options [String, Optional] :format File format used during recording.
       # @option options [String, Optional] :format File format used during recording.
-      # @option options [String, Optional] :initial_timeout Controls how long (milliseconds) the recognizer should wait after the end of the prompt for the caller to speak before sending a Recorder event.
-      # @option options [String, Optional] :final_timeout Controls the length (milliseconds) of a period of silence after callers have spoken to conclude they finished.
+      # @option options [String, Optional] :initial_timeout Controls how long (seconds) the recognizer should wait after the end of the prompt for the caller to speak before sending a Recorder event.
+      # @option options [String, Optional] :final_timeout Controls the length (seconds) of a period of silence after callers have spoken to conclude they finished.
       # @option options [Boolean, Optional] :interruptible Allows the recording to be terminated by any single DTMF key, default is false
       #
       # @return Punchblock::Component::Record
@@ -35,6 +35,9 @@ module Adhearsion
         interruptible = options.delete :interruptible
         interrupt_key = '0123456789#*'
         stopper_component = nil
+        [:max_duration, :initial_timeout, :final_timeout].each do |k|
+          options[k] = options[k].to_i * 1000 if options[k]
+        end
 
         component = Punchblock::Component::Record.new options
         component.register_event_handler Punchblock::Event::Complete do |event|

--- a/spec/adhearsion/call_controller/record_spec.rb
+++ b/spec/adhearsion/call_controller/record_spec.rb
@@ -8,19 +8,23 @@ module Adhearsion
       include CallControllerTestHelpers
 
       describe "#record" do
+        let(:max_duration) { 5 }
         let(:options) do
           {
             :start_beep => true,
-            :max_duration => 5000
+            :max_duration => max_duration
           }
         end
-        let(:component) { Punchblock::Component::Record.new options }
+        let(:parsed_options) do
+          options.merge(max_duration: max_duration * 1000)
+        end
+        let(:component) { Punchblock::Component::Record.new parsed_options }
         let(:response)  { Punchblock::Event::Complete.new }
 
         describe "with :async => true and an :on_complete callback" do
           before do
             component
-            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(options).and_return component
+            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(parsed_options).and_return component
             expect_message_waiting_for_response component
             @rec = Queue.new
             subject.record(options.merge(async: true)) { |rec| @rec.push rec }
@@ -63,7 +67,7 @@ module Adhearsion
         describe "with :async => false" do
           before do
             component
-            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(options).and_return component
+            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(parsed_options).and_return component
             expect_component_execution component
             @rec = Queue.new
             subject.record(options.merge(:async => false)) { |rec| @rec.push rec }
@@ -113,7 +117,7 @@ module Adhearsion
         describe "check for the return value" do
           it "returns a Record component" do
             component
-            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(options).and_return component
+            flexmock(Punchblock::Component::Record).should_receive(:new).once.with(parsed_options).and_return component
             expect_component_execution component
             subject.record(options.merge(:async => false)).should be == component
             component.request!


### PR DESCRIPTION
Simple fix to normalize our input data.
