### PR TITLE
[BUGFIX] Validate menu input before checking the digit limit

### DIFF
--- a/lib/adhearsion/call_controller/menu_dsl/menu.rb
+++ b/lib/adhearsion/call_controller/menu_dsl/menu.rb
@@ -63,9 +63,8 @@ module Adhearsion
           return get_another_digit_or_timeout! if digit_buffer_empty?
 
           return menu_terminated! if @terminated
-          return menu_limit_reached! if limit && digit_buffer.size >= limit
-
           return menu_validator_terminated! if execute_validator_hook
+          return menu_limit_reached! if limit && digit_buffer.size >= limit
 
           calculated_matches = builder.calculate_matches_for digit_buffer_string
 

--- a/spec/adhearsion/call_controller/menu_dsl/menu_spec.rb
+++ b/spec/adhearsion/call_controller/menu_dsl/menu_spec.rb
@@ -363,6 +363,24 @@ module Adhearsion
                   menu_instance.result.should be == '242'
                 end
               end
+
+              context "when a digit limit and validator is defined" do
+                let(:menu_instance) do
+                  Menu.new options.merge(:limit => 3) do
+                    validator { |buffer| buffer == "242" }
+                  end
+                end
+
+                it "applies the validator before checking the digit limit" do
+                  menu_instance << 2
+                  menu_instance << 4
+                  menu_instance << 2
+                  menu_instance.continue.should be_a Menu::MenuValidatorTerminated
+                  menu_instance.continue.should be_a Menu::MenuResultDone
+                  menu_instance.status.should be == :validator_terminated
+                  menu_instance.result.should be == '242'
+                end
+              end
             end
 
           end#continue


### PR DESCRIPTION
Input that has reached the digit limit may or may not be valid but we won't know which if the validator has not been applied first.
