### PR TITLE
[BUGFIX] Ensure the process goes down when finishing shutdown even if not all important threads are finished

### DIFF
--- a/lib/adhearsion/process.rb
+++ b/lib/adhearsion/process.rb
@@ -85,6 +85,7 @@ module Adhearsion
       Console.stop
 
       logger.info "Adhearsion shut down"
+      ::Process.exit
     end
 
     def stop_when_zero_calls

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
 
   config.before :each do
     Adhearsion.router = nil
+    flexmock(::Process).should_receive(:exit).with_no_args.zero_or_more_times
   end
 end
 


### PR DESCRIPTION
@chewi reports that this works well, but tests are failing on 1.9.2

Do we drop support for 1.9.2 on the grounds that 1.9.3 is a perfectly smooth upgrade and there's no good reason not to do it?
