### PR TITLE
[BUGFIX] Create PID file before daemonizing

### DIFF
--- a/lib/adhearsion/initializer.rb
+++ b/lib/adhearsion/initializer.rb
@@ -42,13 +42,18 @@ module Adhearsion
       load_lib_folder
       load_config_file
       initialize_log_paths
-      daemonize! if should_daemonize?
+
+      if should_daemonize?
+        daemonize!
+      else
+        create_pid_file
+      end
+
       Adhearsion.statistics
       start_logging
       debugging_log
       launch_console if need_console?
       catch_termination_signal
-      create_pid_file
       set_ahn_proc_name
       initialize_exception_logger
       update_rails_env_var
@@ -220,7 +225,10 @@ module Adhearsion
       logger.info "Daemonizing now!"
       logger.debug "Creating PID file #{pid_file}"
       extend Adhearsion::CustomDaemonizer
-      daemonize resolve_log_file_path
+
+      daemonize resolve_log_file_path do |pid|
+        create_pid_file pid
+      end
     end
 
     def launch_console
@@ -261,11 +269,11 @@ module Adhearsion
       end
     end
 
-    def create_pid_file
+    def create_pid_file(pid = nil)
       return unless pid_file
 
       File.open pid_file, 'w' do |file|
-        file.puts ::Process.pid
+        file.puts pid || ::Process.pid
       end
 
       Events.register_callback :shutdown do


### PR DESCRIPTION
The short gap between the parent process exiting and the PID file being written occasionally led to monitoring processes such as god believing that the server had failed to launch. Multiple instances would then be started with dire consequences.

You can reproduce the problem more reliably by inserting an artificial sleep in foundation/custom_daemonizer.rb.

``` ruby
    # This method causes the current running process to become a daemon
    def daemonize(log_file = '/dev/null')
      oldmode = 0
      srand # Split rand streams between spawning and daemonized process
      safefork and exit # Fork and exit from the parent

      sleep 5 # !!!

      # Detach from the controlling terminal
      raise 'Cannot detach from controlled terminal' unless sess_id = ::Process.setsid
```

Then fire up ahn like so.

```
rm -f foo.pid && ahn daemon --pid-file foo.pid && cat foo.pid
```

You will see that foo.pid is not found. I found that even a sleep of 1 was enough to reproduce it reliably. After applying the fix, you can set the sleep to be as high as you like and foo.pid will always be found.

Note that I removed the redundant "oldmode" checks (oldmode was always 0) because keeping them would have made this change more complicated.

I tried to amend the tests but the heavy stubbing in Adhearsion::Initializer made this too tricky for me. Ideally we still want daemonize! to run and the block passed to daemonize to be called. It's the daemonize method itself that really needs stubbing. Could I have some help with this?
