### PR TITLE
[BUGFIX] Fixed the 'source' in the app generator to use 'https' explicitly

### DIFF
--- a/features/app_generator.feature
+++ b/features/app_generator.feature
@@ -42,7 +42,7 @@ Feature: Adhearsion App Generator
     And the file "Rakefile" should contain "adhearsion/tasks"
     And the file "Gemfile" should contain each of these content parts:
     """
-    source :rubygems
+    source 'https://rubygems.org
     gem 'adhearsion-asterisk'
     """
     And the file "lib/simon_game.rb" should contain "class SimonGame"

--- a/lib/adhearsion/generators/app/templates/Gemfile.erb
+++ b/lib/adhearsion/generators/app/templates/Gemfile.erb
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "adhearsion", "~> <%= Adhearsion::VERSION.split('.')[0,2].join('.') %>"
 


### PR DESCRIPTION
Fixing the warning that comes while running `bundle install` on newly generated projects.

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
