### PR TITLE
[minor] no "0" in the simon demo

### DIFF
--- a/lib/adhearsion/generators/app/templates/lib/simon_game.rb
+++ b/lib/adhearsion/generators/app/templates/lib/simon_game.rb
@@ -15,7 +15,7 @@ class SimonGame < Adhearsion::CallController
   end
 
   def random_number
-    rand(10).to_s
+    rand(1..9).to_s
   end
 
   def update_number


### PR DESCRIPTION
if genereating the sequence "0" then "05"
  tts engine like flite will speak it as "zero" then "five" # ommiting the leading zero
