### PR TITLE
[CS] Use Celluloid's thread pool for CallControllers

### DIFF
--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -86,7 +86,7 @@ module Adhearsion
     end
 
     def bg_exec(completion_callback = nil)
-      Celluloid.internal_pool.get do
+      Celluloid::ThreadHandle.new do
         catching_standard_errors do
           exec_with_callback completion_callback
         end


### PR DESCRIPTION
@tarcieri Any good reason why we shouldn't do this (other than CallController should be an Actor)?
