### PR TITLE
Do not inherit from BasicObject on ThreadSafeArray

### DIFF
--- a/lib/adhearsion/foundation/thread_safety.rb
+++ b/lib/adhearsion/foundation/thread_safety.rb
@@ -9,7 +9,7 @@ class Object
   end
 end
 
-class ThreadSafeArray < BasicObject
+class ThreadSafeArray
   def initialize
     @mutex = ::Mutex.new
     @array = []


### PR DESCRIPTION
Objects that inherit from BasicObject do not have most of the typical methods defined on standard objects, such as #class, #methods, #inspect, etc.  Because of the behavior of ThreadSafeArray, that means each of these methods gets proxied down to the underlying Array object, guarded by the Mutex.  This has worked fine, but causes problems with the unit tests running on JRuby.  Something about the expectation breaks on JRuby.  The error message implied that the expectation was being checked on the underlying Array object, while it was being defined on the ThreadSafeArray object.

I'm not sure if I like this change so I'm doing it as a PR for review.  Perhaps the right thing to do is to either fix JRuby or to fix RSpec matchers to handle the case where inheritors of BasicObject with a #method_missing defined validates assertions on the correct object.

Ping @benlangfeld
