### PR TITLE
[BUGFIX] Removed unnecessary Mocha reference from generated plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+ * Bugfix: Removed unnecessary Mocha reference from generated plugin
 
 # [2.3.5](https://github.com/adhearsion/adhearsion/compare/v2.3.4...v2.3.5) - [2013-06-06](https://rubygems.org/gems/adhearsion/versions/2.3.5)
   * Bugfix: Fix race conditions in barging in before output start is acknowledged

--- a/lib/adhearsion/generators/plugin/templates/plugin-template.gemspec.tt
+++ b/lib/adhearsion/generators/plugin/templates/plugin-template.gemspec.tt
@@ -26,6 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<bundler>, ["~> 1.0"]
   s.add_development_dependency %q<rspec>, ["~> 2.5"]
   s.add_development_dependency %q<rake>, [">= 0"]
-  s.add_development_dependency %q<mocha>, [">= 0"]
   s.add_development_dependency %q<guard-rspec>
  end

--- a/lib/adhearsion/generators/plugin/templates/spec/spec_helper.rb.tt
+++ b/lib/adhearsion/generators/plugin/templates/spec/spec_helper.rb.tt
@@ -5,7 +5,6 @@ RSpec.configure do |config|
   config.color_enabled = true
   config.tty = true
 
-  config.mock_with :mocha
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
We have been not using Mocha for a while now.
