### PR TITLE
Be able to tell that a {profile=s3}https://... is audio, not a string

### DIFF
--- a/lib/adhearsion/call_controller/output/formatter.rb
+++ b/lib/adhearsion/call_controller/output/formatter.rb
@@ -23,6 +23,7 @@ module Adhearsion
         end
 
         def detect_type(output)
+          output = output.gsub(/^{.+}/, '') if output.class == String
           case output
           when Date, Time, DateTime
             :time

--- a/spec/adhearsion/call_controller/output/formatter_spec.rb
+++ b/spec/adhearsion/call_controller/output/formatter_spec.rb
@@ -47,6 +47,11 @@ module Adhearsion
             subject.detect_type(http_path).should be :audio
           end
 
+          it "detects an HTTP path, even when it has a {profile}" do
+            http_path = "{profile=s3}http://adhearsion.com/sounds/hello.mp3"
+            subject.detect_type(http_path).should be :audio
+          end
+
           it "detects a file path" do
             file_path = "file:///usr/shared/sounds/hello.mp3"
             subject.detect_type(file_path).should be :audio


### PR DESCRIPTION
Because there's nothing like hearing the Flite voice announcing "h t t p s colon slash slash..." :p
