### PR TITLE
[mehak] updating environment.rb to use bundler groups

### DIFF
--- a/lib/adhearsion/generators/app/templates/config/environment.rb
+++ b/lib/adhearsion/generators/app/templates/config/environment.rb
@@ -2,4 +2,4 @@
 
 require 'bundler'
 Bundler.setup
-Bundler.require
+Bundler.require(:default,ENV["AHN_ENV"].to_sym)


### PR DESCRIPTION
Making Changes in the environment so that bundler can require gems based on the groups mentioned in the gemfile.
