### PR TITLE
#dial join options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Feature: Allow preventing automatic call hangup after controller completion. Set `Call#auto_hangup = false` prior to controller termination.
   * Feature: Allow specifying a pre-join callback to #dial
   * Feature: Allow specifying ringback to `#dial` as either a list or a proc
+  * Feature: Allow passing `:join_options` parameter to `#dial` to specify the kind of join to perform.
   * Feature: Generated apps now encourage storing most app code in `app/`, which is in the load path. Nothing in this directory is auto-loaded, but can be easily required without messy relative paths.
   * Bugfix: Don't block shutdown waiting for the console to terminate
   * Bugfix: Ensure that splitting a dial rejoined to an alternative target (eg a mixer) or merged with another dial can still be split properly.


### PR DESCRIPTION
WIP

This is a first whack at implementing #395. There are several things missing here which need to be considered:
- [x] - What if multiple calls each want their own join parameters?
- [x] - What happens with rejoins?
- [x] - What happens when merging dials? This goes to a mixer so necessarily requires bridged media, but direction might need to be specified.
