### PR TITLE
[UPDATE] Drop support for Ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -9,7 +8,6 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: 1.9.2
     - rvm: rbx-2.1.1
     - rvm: ruby-head
 env: ARUBA_TIMEOUT=120 RAILS_ENV=development AHN_ENV=development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * **Change: Ruby 1.9.2 is no longer supported**
   * Change: Set default call post-hangup lifetime to one second for better out of the box performance.
   * Feature: Allow stopping all components executed by a controller when passing from it (`#hard_pass`) or at will (`#stop_all_components`)
   * Feature: Generated plugins include a .gitignore file

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'activesupport', '~> 3.0' if RUBY_VERSION == "1.9.2"

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ Adhearsion rests above a lower-level telephony platform, for example [Asterisk](
 
 ## Requirements
 
-* Ruby 1.9.2+ or JRuby 1.7.0+
+* Ruby 1.9.3+ or JRuby 1.7.0+
 * [ruby_speech dependencies](https://github.com/benlangfeld/ruby_speech#dependencies)
 * A VoIP platform:
   * Asterisk 1.8+
@@ -31,10 +31,7 @@ Adhearsion rests above a lower-level telephony platform, for example [Asterisk](
   * A Rayo server (Prism 11+ with rayo-server, or FreeSWITCH with mod_rayo)
 * An interest in building cool new things
 
-Support for Ruby 1.9.2 is deprecated, and requires locking your application to ActiveSupport 3.x as follows:
-  ```ruby
-  gem 'active_support', '~> 3.0'
-  ```
+**Ruby 1.9.2 is no longer supported by Adhearsion or the Ruby core team. You should upgrade to Ruby 1.9.3 or Ruby 2 as a matter of urgency in order to continue receiving security fixes.**
 
 ## Install
 

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-abort "ERROR: You are running Adhearsion on an unsupported version of Ruby (Ruby #{RUBY_VERSION} #{RUBY_RELEASE_DATE})! Please upgrade to at least Ruby v1.9.2, JRuby 1.7.0 or Rubinius 2.0." if RUBY_VERSION < "1.9.2"
+abort "ERROR: You are running Adhearsion on an unsupported version of Ruby (Ruby #{RUBY_VERSION} #{RUBY_RELEASE_DATE})! Please upgrade to at least Ruby v1.9.3, JRuby 1.7.0 or Rubinius 2.0." if RUBY_VERSION < "1.9.3"
 
 %w{
   active_support/all


### PR DESCRIPTION
Arguments:
- Ruby 1.9.2 reached EOL (does not receive security fixes)
- Upgrading from 1.9.2 to 1.9.3 is trivial
- Most people on 1.9 are already on 1.9.3
- Maintaining support of Adhearsion and related projects on unmaintained Ruby versions is a disservice to our users. There are enough reasons for an upgrade regardless of Adhearsion's support (security issues, etc), suggesting that it's ok to continue using unmaintained language versions is poor advice, and attempting to maintain support distracts us from improving the project (security, bugs, performance and features) on modern maintained platforms.

I suggest that Adhearsion's versioning policy should state that external dependencies (Ruby versions, Asterisk/FS versions) will be supported within a major release of Adhearsion until the point at which they reach their own EOL date, at which point Adhearsion's support for those dependencies will cease to be guaranteed.

Review please @bklang.
