### PR TITLE
[FEATURE] Allow preventing automatic call hangup after controller completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Feature: Detect something like "1234#" as characters instead of text
   * Feature: Add `--empty` switch to app generator for power users. Generates an app with less fluff.
   * Feature: Default generated applications with config appropriate for [Telephony Dev Box](http://github.com/mojolingo/Telephony-Dev-Box)
+  * Feature: Allow preventing automatic call hangup after controller completion. Set `Call#auto_hangup = false` prior to controller termination.
   * Bugfix: Don't block shutdown waiting for the console to terminate
   * Bugfix: Ensure that splitting a dial rejoined to an alternative target (eg a mixer) or merged with another dial can still be split properly.
   * Bugfix: Ensure that hungup calls don't prevent dial splits/merges.

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -45,6 +45,9 @@ module Adhearsion
     # @return [Time] the time at which the call began. For inbound calls this is the time at which the call was offered to Adhearsion. For outbound calls it is the time at which the remote party answered.
     attr_reader :end_time
 
+    # @return [true, false] wether or not the call should be automatically hung up after executing its controller
+    attr_accessor :auto_hangup
+
     delegate :[], :[]=, :to => :variables
 
     # @return [String] the value of the To header from the signaling protocol
@@ -74,6 +77,7 @@ module Adhearsion
       @end_blocker  = Celluloid::Condition.new
       @peers        = {}
       @duration     = nil
+      @auto_hangup  = true
 
       self << offer if offer
     end

--- a/lib/adhearsion/router/openended_route.rb
+++ b/lib/adhearsion/router/openended_route.rb
@@ -8,7 +8,7 @@ module Adhearsion
       end
 
       def dispatch(call, callback = nil)
-        call[:ahn_prevent_hangup] = true
+        call.auto_hangup = false
         super
       end
     end

--- a/lib/adhearsion/router/route.rb
+++ b/lib/adhearsion/router/route.rb
@@ -38,10 +38,11 @@ module Adhearsion
 
         call.execute_controller controller, lambda { |call_actor|
           begin
-            if call_actor[:ahn_prevent_hangup]
-              logger.info "Call routing completed, keeping the call alive at controller/router request."
-            else
+            if call_actor.auto_hangup
+              logger.info "Call routing completed. Hanging up now..."
               call_actor.hangup
+            else
+              logger.info "Call routing completed, keeping the call alive at controller/router request."
             end
           rescue Call::Hangup, Call::ExpiredError
           end

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -57,6 +57,8 @@ module Adhearsion
     its(:to)      { should be == to }
     its(:from)    { should be == from }
 
+    its(:auto_hangup) { should be_true }
+
     context "when the ID is nil" do
       let(:call_id) { nil }
 

--- a/spec/adhearsion/router/route_spec.rb
+++ b/spec/adhearsion/router/route_spec.rb
@@ -159,8 +159,8 @@ module Adhearsion
             end
           end
 
-          context 'with the :ahn_prevent_hangup call variable set' do
-            before { call[:ahn_prevent_hangup] = true }
+          context 'with the Call#auto_hangup set to false' do
+            before { call.auto_hangup = false }
 
             it "should not hangup the call after controller execution" do
               call.should_receive(:hangup).never


### PR DESCRIPTION
Set `Call#auto_hangup = false` prior to controller termination.

Fixes #407
