### PR TITLE
[FEATURE] Generated apps now encourage storing most app code in `app/`, which is in the load path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Feature: Allow preventing automatic call hangup after controller completion. Set `Call#auto_hangup = false` prior to controller termination.
   * Feature: Allow specifying a pre-join callback to #dial
   * Feature: Allow specifying ringback to `#dial` as either a list or a proc
+  * Feature: Generated apps now encourage storing most app code in `app/`, which is in the load path. Nothing in this directory is auto-loaded, but can be easily required without messy relative paths.
   * Bugfix: Don't block shutdown waiting for the console to terminate
   * Bugfix: Ensure that splitting a dial rejoined to an alternative target (eg a mixer) or merged with another dial can still be split properly.
   * Bugfix: Ensure that hungup calls don't prevent dial splits/merges.

--- a/features/app_generator.feature
+++ b/features/app_generator.feature
@@ -7,6 +7,7 @@ Feature: Adhearsion App Generator
     When I run `ahn create path/somewhere`
     And I cd to "path/somewhere"
     Then the following directories should exist:
+      | app/call_controllers  |
       | lib                   |
       | config                |
       | script                |
@@ -17,10 +18,10 @@ Feature: Adhearsion App Generator
     And the following files should exist:
       | .gitignore                                |
       | .rspec                                    |
+      | app/call_controllers/simon_game.rb        |
       | config/adhearsion.rb                      |
       | config/environment.rb                     |
       | Gemfile                                   |
-      | lib/simon_game.rb                         |
       | script/ahn                                |
       | spec/spec_helper.rb                       |
       | spec/call_controllers/simon_game_spec.rb  |
@@ -46,13 +47,14 @@ Feature: Adhearsion App Generator
     source 'https://rubygems.org
     gem 'adhearsion-asr'
     """
-    And the file "lib/simon_game.rb" should contain "class SimonGame"
+    And the file "app/call_controllers/simon_game.rb" should contain "class SimonGame"
     And the file "script/ahn" should contain "require 'adhearsion'"
 
   Scenario: Generate application --empty
     When I run `ahn create path/somewhere --empty`
     And I cd to "path/somewhere"
     Then the following directories should exist:
+      | app/call_controllers  |
       | lib                   |
       | config                |
       | script                |
@@ -73,7 +75,7 @@ Feature: Adhearsion App Generator
       | Procfile              |
 
     And the following files should not exist:
-      | lib/simon_game.rb                         |
+      | app/call_controllers/simon_game.rb        |
       | spec/call_controllers/simon_game_spec.rb  |
 
     And the file "config/adhearsion.rb" should not contain each of these content parts:

--- a/lib/adhearsion/generators/app/app_generator.rb
+++ b/lib/adhearsion/generators/app/app_generator.rb
@@ -5,7 +5,7 @@ module Adhearsion
     class AppGenerator < Generator
 
       BASEDIRS  = %w( config script spec )
-      EMPTYDIRS = %w( lib spec/support spec/call_controllers )
+      EMPTYDIRS = %w( app/call_controllers lib spec/support spec/call_controllers )
 
       class_option :empty, type: :boolean
 
@@ -22,7 +22,7 @@ module Adhearsion
         copy_file "Rakefile"
         copy_file "README.md"
         unless options[:empty]
-          copy_file "simon_game.rb", "lib/simon_game.rb"
+          copy_file "simon_game.rb", "app/call_controllers/simon_game.rb"
           copy_file "simon_game_spec.rb", "spec/call_controllers/simon_game_spec.rb"
         end
         chmod "script/ahn", 0755

--- a/lib/adhearsion/generators/app/templates/adhearsion.erb
+++ b/lib/adhearsion/generators/app/templates/adhearsion.erb
@@ -64,6 +64,10 @@ Adhearsion::Events.draw do
 <% end %>
 end
 
+<% unless options[:empty] %>
+require 'call_controllers/simon_game'
+<% end %>
+
 Adhearsion.router do
 <% if options[:empty] %>
   route 'default' do

--- a/lib/adhearsion/generators/app/templates/config/environment.rb
+++ b/lib/adhearsion/generators/app/templates/config/environment.rb
@@ -6,3 +6,5 @@ Bundler.setup
 require 'adhearsion'
 
 Bundler.require(:default, Adhearsion.environment)
+
+$LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), '../app/')))


### PR DESCRIPTION
Nothing in this directory is auto-loaded, but can be easily required without messy relative paths.

@JustinAiken Please review for satisfaction of #352
