### PR TITLE
[FEATURE] Generate applications with an explicit dependency on Punchblock

### DIFF
--- a/lib/adhearsion/generators/app/templates/Gemfile.erb
+++ b/lib/adhearsion/generators/app/templates/Gemfile.erb
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 
 gem 'adhearsion', '~> <%= Adhearsion::VERSION.split('.')[0,2].join('.') %>'
 
-# Adhearsion depends on the Punchblock library, but here you can specify the major version your application depends on
+# Adhearsion depends on the Punchblock library, but here you can specify the major version your application depends on.
+# Exercise care when updating the major version, since you might encounter API compatability in parts of your Adhearsion application that rely on the Punchblock API.
+# On occasion, an update of Adhearsion might necessitate an update to Punchblock. You will have to manually allow that here, and take care in the upgrade.
 gem 'punchblock', '~> <%= Punchblock::VERSION.split('.')[0,2].join('.') %>'
 
 # This is here by default due to deprecation of #ask and #menu.


### PR DESCRIPTION
- Many users of Adhearsion make direct use of Punchblock APIs (mostly command/event models) which are subject to Punchblock's own versioning.
- Adhearsion occasionally bumps the dependent Punchblock major version number in minor releases to gain access to new functionality that required such a bump in Punchblock, on the basis that this does not impact Adhearsion's API itself.

These two facts combine to produce the potential for breakage of an Adhearsion application by updating the Adhearsion minor version.

Generating an application with a specific dependency on Punchblock prevents bumping the Asterisk version if it requires a major version of Punchblock greater than the app was generated in, forcing the user to manually update the Punchblock version in their Gemfile at this point. This forces the user to consider their Punchblock API dependency and prepare for potential breakage.
