### PR TITLE
Should use Rayo event timestamps for signaling timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Bugfix: Delay configuring plugins until after initialisation. Allows plugin config to use things which are not set until initialisation like the current working directory, Adhearsion.root, etc. https://github.com/adhearsion/adhearsion-i18n/issues/4
   * Bugfix: Calls which are dead but can still be found now log a warning when receiving events
   * Bugfix: Cleanup generated application routes spacing
+  * Bugfix: Use Rayo event timestamps for timing call operations. These timestamps are more accurate than using the time of event processing since event delivery/processing might be delayed due to network conditions or application load. This enables more reliable billing. ([#454](https://github.com/adhearsion/adhearsion/pull/454))
 
 # [2.5.0](https://github.com/adhearsion/adhearsion/compare/v2.4.0...v2.5.0) - [2014-02-03](https://rubygems.org/gems/adhearsion/versions/2.5.0)
   * **Change: Ruby 1.9.2 is no longer supported**

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jruby-openssl' if RUBY_PLATFORM == 'java'
   s.add_runtime_dependency 'logging', ["~> 1.8"]
   s.add_runtime_dependency 'pry'
-  s.add_runtime_dependency 'punchblock', ["~> 2.3"]
+  s.add_runtime_dependency 'punchblock', ["~> 2.4"]
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'ruby_speech', ["~> 2.0"]
   s.add_runtime_dependency 'thor', "~> 0.18.0"

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -195,7 +195,7 @@ module Adhearsion
       register_event_handler Punchblock::Event::Offer do |offer|
         @offer  = offer
         @client = offer.client
-        @start_time = Time.now
+        @start_time = offer.timestamp.to_time
       end
 
       register_event_handler Punchblock::HasHeaders do |event|
@@ -231,7 +231,7 @@ module Adhearsion
 
       on_end do |event|
         logger.info "Call ended due to #{event.reason}"
-        @end_time = Time.now
+        @end_time = event.timestamp.to_time
         @duration = @end_time - @start_time if @start_time
         clear_from_active_calls
         @end_reason = event.reason

--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -163,7 +163,7 @@ module Adhearsion
               pre_confirmation_tasks new_call
 
               new_call.on_unjoined @call do |unjoined|
-                join_status.ended
+                join_status.ended unjoined.timestamp.to_time
                 unless @splitting
                   new_call["dial_countdown_#{@id}"] = true
                   @latch.countdown!
@@ -520,8 +520,8 @@ module Adhearsion
           @result = :joined
         end
 
-        def ended
-          @end_time = Time.now
+        def ended(time)
+          @end_time = time
         end
       end
 

--- a/lib/adhearsion/outbound_call.rb
+++ b/lib/adhearsion/outbound_call.rb
@@ -83,7 +83,7 @@ module Adhearsion
     # @private
     def register_initial_handlers
       super
-      on_answer { |event| @start_time = Time.now }
+      on_answer { |event| @start_time = event.timestamp.to_time }
     end
 
     def run_router

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -18,13 +18,15 @@ module Adhearsion
     let(:to)      { 'sip:you@there.com' }
     let(:from)    { 'sip:me@here.com' }
     let(:transport) { 'footransport' }
+    let(:base_time) { Time.local(2008, 9, 1, 12, 0, 0) }
     let :offer do
       Punchblock::Event::Offer.new target_call_id: call_id,
                                    domain: domain,
                                    transport: transport,
                                    to: to,
                                    from: from,
-                                   headers: headers
+                                   headers: headers,
+                                   timestamp: base_time
     end
 
     subject { Adhearsion::Call.new offer }
@@ -85,8 +87,6 @@ module Adhearsion
     end
 
     it "should mark its start time" do
-      base_time = Time.local(2008, 9, 1, 12, 0, 0)
-      Timecop.freeze base_time
       subject.start_time.should == base_time
     end
 


### PR DESCRIPTION
Call answered/hangup times, etc. Don't use `Time.now` anywhere.
