### PR TITLE
Bump the min rspec development dependency to 2.13

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'guard-cucumber'
   s.add_development_dependency 'guard-rspec'
-  s.add_development_dependency 'rspec', ["~> 2.11"]
+  s.add_development_dependency 'rspec', ["~> 2.13"]
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'yard'


### PR DESCRIPTION
Similar to adhearsion/punchblock#215

The Adhearsion spec suite implicitly requires rspec 2.13 or higher.  Anything less, and you get unexpected errors.  This just formalizes the updated dependency requirement.

On rspec < 2.12, you'd get this before any tests ran at all:

$ cd adhearsion
$ bundle exec rspec spec

```
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:334:in `mock_with': RSpec::Core::MockFrameworkAdapter must respond to `configuration` so that mock_with can yield it. (RuntimeError)
    from /Users/sgeorge/Code/adhearsion/adhearsion-core/spec/spec_helper.rb:30:in `block in <top (required)>'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core.rb:92:in `configure'
    from /Users/sgeorge/Code/adhearsion/adhearsion-core/spec/spec_helper.rb:23:in `<top (required)>'
    from /Users/sgeorge/Code/adhearsion/adhearsion-core/spec/adhearsion/call_controller/dial_spec.rb:3:in `require'
    from /Users/sgeorge/Code/adhearsion/adhearsion-core/spec/adhearsion/call_controller/dial_spec.rb:3:in `<top (required)>'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `block in load_spec_files'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `map'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load_spec_files'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
    from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'
[Coveralls] Outside the Travis environment, not sending data.
```

2.13.0 seems to be the minimum version for tests to both run and pass.
