### PR TITLE
[BUGFIX] Call handlers can be registered with additional options

### DIFF
--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -17,7 +17,7 @@ module Adhearsion
     include Celluloid
     include HasGuardedHandlers
 
-    execute_block_on_receiver :register_handler, :register_tmp_handler, :register_handler_with_priority, :register_event_handler, :on_joined, :on_unjoined, :on_end, :execute_controller, *execute_block_on_receiver
+    execute_block_on_receiver :register_handler, :register_tmp_handler, :register_handler_with_priority, :register_handler_with_options, :register_event_handler, :on_joined, :on_unjoined, :on_end, :execute_controller, *execute_block_on_receiver
     finalizer :finalize
 
     def self.new(*args, &block)


### PR DESCRIPTION
Currently, a handler cannot be registered on a call as both temporary and with a priority because `#register_handler_with_options` is not specified in the call to `execute_block_on_receiver`.  This PR fixes this issue.
