### PR TITLE
Core method for Transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Feature: Add `Call#redirect` and `CallController#redirect` for redirecting calls to other systems ([#465](https://github.com/adhearsion/adhearsion/issues/465))
   * Bugfix: Do not quiesce until the second SIGTERM, as per documentation ([#483](https://github.com/adhearsion/adhearsion/issues/483))
   * Bugfix: Consistent support for output options in all output methods ([#481](https://github.com/adhearsion/adhearsion/issues/481))
 

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -306,6 +306,15 @@ module Adhearsion
       Adhearsion::Events.trigger_immediately :call_rejected, call: current_actor, reason: reason
     end
 
+    #
+    # Redirect the call to some other target system
+    #
+    # @param [String] to the target to redirect to, eg a SIP URI
+    # @param [Hash, optional] headers a set of headers to send along with the redirect instruction
+    def redirect(to, headers = nil)
+      write_and_await_response Punchblock::Command::Redirect.new(to: to, headers: headers)
+    end
+
     def hangup(headers = nil)
       return false unless active?
       logger.info "Hanging up"

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -251,6 +251,17 @@ module Adhearsion
     end
 
     #
+    # Redirect the call to some other target
+    #
+    # @see Call#redirect
+    #
+    def redirect(*args)
+      block_until_resumed
+      call.redirect(*args)
+      raise Call::Hangup
+    end
+
+    #
     # Mute the call
     #
     # @see Call#mute

--- a/spec/adhearsion/call_controller_spec.rb
+++ b/spec/adhearsion/call_controller_spec.rb
@@ -391,7 +391,8 @@ module Adhearsion
 
     [
       :hangup,
-      :reject
+      :reject,
+      :redirect
     ].each do |method_name|
       describe "##{method_name}" do
         it "delegates to the call, blocking first until it is allowed to execute, and raises Call::Hangup" do

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -876,6 +876,40 @@ module Adhearsion
         end
       end
 
+      describe '#redirect' do
+        describe "with a target given" do
+          it 'should send a Redirect message with the correct target' do
+            expect_message_waiting_for_response Punchblock::Command::Redirect.new(to: 'sip:foo@bar.com')
+            subject.redirect 'sip:foo@bar.com'
+          end
+        end
+
+        describe "with no target given" do
+          it 'should raise with ArgumentError' do
+            expect { subject.redirect }.to raise_error(ArgumentError)
+          end
+        end
+
+        describe "with no headers" do
+          it 'should send a Redirect message' do
+            expect_message_waiting_for_response do |c|
+              c.is_a?(Punchblock::Command::Redirect) && c.headers == {}
+            end
+            subject.redirect 'sip:foo@bar.com'
+          end
+        end
+
+        describe "with headers set" do
+          it 'should send a Redirect message with the correct headers' do
+            headers = {:foo => 'bar'}
+            expect_message_waiting_for_response do |c|
+              c.is_a?(Punchblock::Command::Redirect) && c.headers == headers
+            end
+            subject.redirect 'sip:foo@bar.com', headers
+          end
+        end
+      end
+
       describe "#hangup" do
         describe "if the call is not active" do
           before do


### PR DESCRIPTION
I would like Adhearsion to have a `#transfer` CallController method.  For simplicity, let's start with a blind transfer.

The effect should be something like:

``` Ruby
def transfer(destination)
  write_and_await_response Punchblock::Command::Redirect.new(to: destination)
end
```

The only problem with this method is that the calling CallController attempts to continue.  The effect of transfer should be understood to implicitly end the call like a `#hangup`.
