### PR TITLE
Make latch waits consistent and configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ matrix:
   allow_failures:
     - rvm: rbx-2.1.1
     - rvm: ruby-head
-env: ARUBA_TIMEOUT=120 RAILS_ENV=development AHN_ENV=development
+env: ARUBA_TIMEOUT=120 RAILS_ENV=development AHN_ENV=development LATCH_TIMEOUT=10
 notifications:
   irc: "irc.freenode.org#adhearsion"

--- a/spec/adhearsion/call_controller/dial_spec.rb
+++ b/spec/adhearsion/call_controller/dial_spec.rb
@@ -82,7 +82,7 @@ module Adhearsion
 
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           it "unblocks the original controller if the original call ends" do
@@ -93,7 +93,7 @@ module Adhearsion
 
             call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           it "joins the new call to the existing one on answer" do
@@ -107,7 +107,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           context "with a join target specified" do
@@ -125,7 +125,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
           end
 
@@ -145,7 +145,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
           end
 
@@ -171,7 +171,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
 
             context "as a callback" do
@@ -191,7 +191,7 @@ module Adhearsion
                 other_mock_call << mock_answered
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
               end
             end
 
@@ -206,7 +206,7 @@ module Adhearsion
 
                 other_mock_call << mock_end(:reject)
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
               end
             end
           end
@@ -223,7 +223,7 @@ module Adhearsion
             other_mock_call << mock_answered
             call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           context "when the call is rejected" do
@@ -234,7 +234,7 @@ module Adhearsion
 
               other_mock_call << mock_end(:reject)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -250,7 +250,7 @@ module Adhearsion
 
               other_mock_call << mock_end(:error)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -277,7 +277,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -309,7 +309,7 @@ module Adhearsion
               other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -335,7 +335,7 @@ module Adhearsion
                 other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 t.join
               end
@@ -378,7 +378,7 @@ module Adhearsion
               dial.split
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               dial.status.result.should be == :answer
@@ -403,7 +403,7 @@ module Adhearsion
 
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               dial.status.result.should be == :answer
@@ -433,7 +433,7 @@ module Adhearsion
               Timecop.freeze base_time
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               status = dial.status
@@ -480,7 +480,7 @@ module Adhearsion
                 dial.split main: main_split_controller, others: others_split_controller, main_callback: ->(call) { self.callback(call) }, others_callback: ->(call) { self.callback(call) }
 
                 latch.wait(2).should be_false
-                split_latch.wait(2).should be_true
+                split_latch.wait(LATCH_TIMEOUT).should be_true
 
                 call['hit_split_controller'].should == main_split_controller
                 call['split_controller_metadata']['current_dial'].should be dial
@@ -490,7 +490,7 @@ module Adhearsion
 
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -523,7 +523,7 @@ module Adhearsion
 
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -595,7 +595,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -631,7 +631,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -671,7 +671,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -732,7 +732,7 @@ module Adhearsion
                 second_root_call.async << mock_end
                 second_other_mock_call.async << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -770,7 +770,7 @@ module Adhearsion
                 second_root_call.async << mock_end
                 second_other_mock_call.async << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -796,7 +796,7 @@ module Adhearsion
                 latch.wait(2).should be_false
 
                 second_root_call << mock_end
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -821,7 +821,7 @@ module Adhearsion
                 sleep 0.5
 
                 call << mock_end
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -876,7 +876,7 @@ module Adhearsion
                   second_root_call.async << mock_end
                   second_other_mock_call.async << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -897,13 +897,13 @@ module Adhearsion
                   sleep 0.5
 
                   other_mock_call << mock_end
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   second_other_mock_call << mock_end
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   second_root_call << mock_end
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -930,7 +930,7 @@ module Adhearsion
                   sleep 0.5
 
                   call << mock_end
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -999,7 +999,7 @@ module Adhearsion
                   second_root_call.async << mock_end
                   second_other_mock_call.async << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -1060,7 +1060,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
 
             t.join
             status = t.value
@@ -1084,7 +1084,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
 
             t.join
             status = t.value
@@ -1158,7 +1158,7 @@ module Adhearsion
               other_mock_call << mock_end
               latch.wait(2).should be_false
               second_other_mock_call << mock_end
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
               t.join
             end
           end
@@ -1172,7 +1172,7 @@ module Adhearsion
               other_mock_call << mock_end(:reject)
               second_other_mock_call << mock_end(:reject)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1195,7 +1195,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1251,7 +1251,7 @@ module Adhearsion
 
               other_mock_call << mock_end
 
-              latch.wait(0.1).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
               time = Time.now - time
               time.to_i.should be > timeout
               t.join
@@ -1302,8 +1302,8 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              confirmation_latch.wait(2).should be_true
-              latch.wait(2).should be_true
+              confirmation_latch.wait(LATCH_TIMEOUT).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               other_mock_call[:foo].should == 'bar'
             end
@@ -1327,8 +1327,8 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              confirmation_latch.wait(2).should be_true
-              latch.wait(2).should be_true
+              confirmation_latch.wait(LATCH_TIMEOUT).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
 
             it "should join the calls if the call is still active after execution of the call controller" do
@@ -1353,7 +1353,7 @@ module Adhearsion
               other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1378,7 +1378,7 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1429,11 +1429,11 @@ module Adhearsion
                 latch.wait(2).should be_false
 
                 other_mock_call << mock_answered
-                confirmation_latch.wait(2).should be_true
+                confirmation_latch.wait(LATCH_TIMEOUT).should be_true
 
                 other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 t.join
                 status = t.value
@@ -1499,7 +1499,7 @@ module Adhearsion
 
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           it "unblocks the original controller if the original call ends" do
@@ -1510,7 +1510,7 @@ module Adhearsion
 
             call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           it "joins the new call to the existing one on answer" do
@@ -1524,7 +1524,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           context "with a join target specified" do
@@ -1542,7 +1542,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
           end
 
@@ -1562,7 +1562,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
           end
 
@@ -1588,7 +1588,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
 
             context "as a callback" do
@@ -1608,7 +1608,7 @@ module Adhearsion
                 other_mock_call << mock_answered
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
               end
             end
 
@@ -1623,7 +1623,7 @@ module Adhearsion
 
                 other_mock_call << mock_end(:reject)
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
               end
             end
           end
@@ -1640,7 +1640,7 @@ module Adhearsion
             other_mock_call << mock_answered
             call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
 
           context "when the call is rejected" do
@@ -1651,7 +1651,7 @@ module Adhearsion
 
               other_mock_call << mock_end(:reject)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1667,7 +1667,7 @@ module Adhearsion
 
               other_mock_call << mock_end(:error)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1694,7 +1694,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1726,7 +1726,7 @@ module Adhearsion
               other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -1755,7 +1755,7 @@ module Adhearsion
                 other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 t.join
               end
@@ -1798,7 +1798,7 @@ module Adhearsion
               dial.split
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               dial.status.result.should be == :answer
@@ -1823,7 +1823,7 @@ module Adhearsion
 
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               dial.status.result.should be == :answer
@@ -1853,7 +1853,7 @@ module Adhearsion
               Timecop.freeze base_time
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               waiter_thread.join
               status = dial.status
@@ -1900,7 +1900,7 @@ module Adhearsion
                 dial.split main: main_split_controller, others: others_split_controller, main_callback: ->(call) { self.callback(call) }, others_callback: ->(call) { self.callback(call) }
 
                 latch.wait(2).should be_false
-                split_latch.wait(2).should be_true
+                split_latch.wait(LATCH_TIMEOUT).should be_true
 
                 call['hit_split_controller'].should == main_split_controller
                 call['split_controller_metadata']['current_dial'].should be dial
@@ -1910,7 +1910,7 @@ module Adhearsion
 
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -1946,7 +1946,7 @@ module Adhearsion
 
                 other_mock_call << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -2024,7 +2024,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -2060,7 +2060,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -2100,7 +2100,7 @@ module Adhearsion
 
                   other_mock_call << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -2161,7 +2161,7 @@ module Adhearsion
                 second_root_call.async << mock_end
                 second_other_mock_call.async << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -2199,7 +2199,7 @@ module Adhearsion
                 second_root_call.async << mock_end
                 second_other_mock_call.async << mock_end
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -2225,7 +2225,7 @@ module Adhearsion
                 latch.wait(2).should be_false
 
                 second_root_call << mock_end
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -2250,7 +2250,7 @@ module Adhearsion
                 sleep 0.5
 
                 call << mock_end
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 waiter_thread.join
                 dial.status.result.should be == :answer
@@ -2350,7 +2350,7 @@ module Adhearsion
                   second_root_call.async << mock_end
                   second_other_mock_call.async << mock_end
 
-                  latch.wait(2).should be_true
+                  latch.wait(LATCH_TIMEOUT).should be_true
 
                   waiter_thread.join
                   dial.status.result.should be == :answer
@@ -2411,7 +2411,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
 
             t.join
             status = t.value
@@ -2435,7 +2435,7 @@ module Adhearsion
             other_mock_call << mock_answered
             other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
 
             t.join
             status = t.value
@@ -2509,7 +2509,7 @@ module Adhearsion
               other_mock_call << mock_end
               latch.wait(2).should be_false
               second_other_mock_call << mock_end
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
               t.join
             end
           end
@@ -2523,7 +2523,7 @@ module Adhearsion
               other_mock_call << mock_end(:reject)
               second_other_mock_call << mock_end(:reject)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -2546,7 +2546,7 @@ module Adhearsion
               other_mock_call << mock_answered
               other_mock_call << mock_end
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -2602,7 +2602,7 @@ module Adhearsion
 
               other_mock_call << mock_end
 
-              latch.wait(0.1).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
               time = Time.now - time
               time.to_i.should be > timeout
               t.join
@@ -2656,8 +2656,8 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              confirmation_latch.wait(2).should be_true
-              latch.wait(2).should be_true
+              confirmation_latch.wait(LATCH_TIMEOUT).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               other_mock_call[:foo].should == 'bar'
             end
@@ -2681,8 +2681,8 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              confirmation_latch.wait(2).should be_true
-              latch.wait(2).should be_true
+              confirmation_latch.wait(LATCH_TIMEOUT).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
 
             it "should join the calls if the call is still active after execution of the call controller" do
@@ -2709,7 +2709,7 @@ module Adhearsion
               Timecop.freeze base_time
               other_mock_call << Punchblock::Event::Unjoined.new(call_uri: call.id)
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -2734,7 +2734,7 @@ module Adhearsion
 
               other_mock_call << mock_answered
 
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
 
               t.join
               status = t.value
@@ -2801,13 +2801,13 @@ module Adhearsion
 
                 other_mock_call.async.deliver_message mock_answered
                 second_other_mock_call.async.deliver_message mock_answered
-                confirmation_latch.wait(2).should be_true
+                confirmation_latch.wait(LATCH_TIMEOUT).should be_true
 
                 sleep 2
 
                 other_mock_call.async.deliver_message Punchblock::Event::Unjoined.new(call_uri: call.id)
 
-                latch.wait(2).should be_true
+                latch.wait(LATCH_TIMEOUT).should be_true
 
                 second_other_mock_call['apology_done'].should be_true
                 second_other_mock_call['apology_metadata'].should == {'foo' => 'bar'}
@@ -2861,7 +2861,7 @@ module Adhearsion
             other_mock_call << mock_answered
             call << mock_end
 
-            latch.wait(2).should be_true
+            latch.wait(LATCH_TIMEOUT).should be_true
           end
         end
 
@@ -2890,7 +2890,7 @@ module Adhearsion
                 dial.cleanup_calls
                 latch.countdown!
               end
-              latch.wait(2).should be_true
+              latch.wait(LATCH_TIMEOUT).should be_true
             end
           end
         end

--- a/spec/adhearsion/call_controller/record_spec.rb
+++ b/spec/adhearsion/call_controller/record_spec.rb
@@ -199,7 +199,7 @@ module Adhearsion
             component.request!
             component.execute!
             component.trigger_event_handler response
-            latch.wait(1).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
             Adhearsion::Events.clear_handlers :exception
           end
         end

--- a/spec/adhearsion/call_controller_spec.rb
+++ b/spec/adhearsion/call_controller_spec.rb
@@ -76,7 +76,7 @@ module Adhearsion
           latch.countdown!
         end
         expect { subject.exec }.to raise_error
-        latch.wait(1).should be true
+        latch.wait(LATCH_TIMEOUT).should be true
         ex.should be_a StandardError
         lo.should be subject.logger
       end
@@ -416,7 +416,7 @@ module Adhearsion
         subject.call << Punchblock::Event::Joined.new(call_uri: 'call1')
         latch.wait(1).should be false
         subject.call << Punchblock::Event::Unjoined.new(call_uri: 'call1')
-        latch.wait(1).should be true
+        latch.wait(LATCH_TIMEOUT).should be true
       end
 
       context "with a mixer" do
@@ -432,7 +432,7 @@ module Adhearsion
           subject.call << Punchblock::Event::Joined.new(:mixer_name => 'foobar')
           latch.wait(1).should be false
           subject.call << Punchblock::Event::Unjoined.new(:mixer_name => 'foobar')
-          latch.wait(1).should be true
+          latch.wait(LATCH_TIMEOUT).should be true
         end
       end
 
@@ -447,7 +447,7 @@ module Adhearsion
           end
           latch.wait(1).should be false
           subject.call << Punchblock::Event::Joined.new(call_uri: 'call1')
-          latch.wait(1).should be true
+          latch.wait(LATCH_TIMEOUT).should be true
         end
 
         context "with a mixer" do
@@ -461,7 +461,7 @@ module Adhearsion
             end
             latch.wait(1).should be false
             subject.call << Punchblock::Event::Joined.new(:mixer_name => 'foobar')
-            latch.wait(1).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
         end
       end
@@ -495,7 +495,7 @@ module Adhearsion
 
           subject.resume!
 
-          latch.wait(1).should be_true
+          latch.wait(LATCH_TIMEOUT).should be_true
 
           (t2 - t1).should >= 0.5
         end
@@ -658,7 +658,7 @@ describe ExampleCallController do
       latch.countdown!
     end
     subject.exec
-    latch.wait(1).should be true
+    latch.wait(LATCH_TIMEOUT).should be true
     Adhearsion::Events.clear_handlers :exception
   end
 

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -379,7 +379,7 @@ module Adhearsion
           end
           subject.register_event_handler { |e| raise 'foo' }
           lambda { subject << :foo }.should_not raise_error
-          latch.wait(3).should be true
+          latch.wait(LATCH_TIMEOUT).should be true
           Adhearsion::Events.clear_handlers :exception
         end
       end
@@ -989,7 +989,7 @@ module Adhearsion
             result[:joined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Joined.new(call_uri: uri)
-            result[:joined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should return something that can be blocked on until the entities are unjoined" do
@@ -1002,7 +1002,7 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Unjoined.new(call_uri: uri)
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should unblock all conditions on call end if no joined/unjoined events are received" do
@@ -1013,8 +1013,8 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::End.new
-            result[:joined_condition].wait(0.5).should be_true
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should not error on call end when joined/unjoined events are received correctly" do
@@ -1070,7 +1070,7 @@ module Adhearsion
             result[:joined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Joined.new(call_uri: uri)
-            result[:joined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should return something that can be blocked on until the entities are unjoined" do
@@ -1083,7 +1083,7 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Unjoined.new(call_uri: uri)
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should unblock all conditions on call end if no joined/unjoined events are received" do
@@ -1094,8 +1094,8 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::End.new
-            result[:joined_condition].wait(0.5).should be_true
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should not error on call end when joined/unjoined events are received correctly" do
@@ -1152,7 +1152,7 @@ module Adhearsion
             result[:joined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Joined.new(call_uri: uri)
-            result[:joined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should return something that can be blocked on until the entities are unjoined" do
@@ -1165,7 +1165,7 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Unjoined.new(call_uri: uri)
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should unblock all conditions on call end if no joined/unjoined events are received" do
@@ -1176,8 +1176,8 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::End.new
-            result[:joined_condition].wait(0.5).should be_true
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should not error on call end when joined/unjoined events are received correctly" do
@@ -1233,7 +1233,7 @@ module Adhearsion
             result[:joined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Joined.new(mixer_name: mixer_name)
-            result[:joined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should return something that can be blocked on until the entities are unjoined" do
@@ -1246,7 +1246,7 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::Unjoined.new(mixer_name: mixer_name)
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should unblock all conditions on call end if no joined/unjoined events are received" do
@@ -1257,8 +1257,8 @@ module Adhearsion
             result[:unjoined_condition].wait(0.5).should be_false
 
             subject << Punchblock::Event::End.new
-            result[:joined_condition].wait(0.5).should be_true
-            result[:unjoined_condition].wait(0.5).should be_true
+            result[:joined_condition].wait(LATCH_TIMEOUT).should be_true
+            result[:unjoined_condition].wait(LATCH_TIMEOUT).should be_true
           end
 
           it "should not error on call end when joined/unjoined events are received correctly" do
@@ -1379,7 +1379,7 @@ module Adhearsion
         it "should call #bg_exec on the controller instance" do
           mock_controller.should_receive(:exec).once
           subject.execute_controller mock_controller, lambda { |call| latch.countdown! }
-          latch.wait(3).should be_true
+          latch.wait(LATCH_TIMEOUT).should be_true
         end
 
         it "should use the passed block as a controller if none is specified" do
@@ -1388,7 +1388,7 @@ module Adhearsion
           subject.execute_controller nil, lambda { |call| latch.countdown! } do
             foo
           end
-          latch.wait(3).should be_true
+          latch.wait(LATCH_TIMEOUT).should be_true
         end
 
         it "should raise ArgumentError if both a controller and a block are passed" do
@@ -1403,21 +1403,21 @@ module Adhearsion
             latch.countdown!
           end
           subject.execute_controller BrokenController.new(subject), lambda { |call| latch.countdown! }
-          latch.wait(3).should be true
+          latch.wait(LATCH_TIMEOUT).should be true
           Adhearsion::Events.clear_handlers :exception
         end
 
         it "should execute a callback after the controller executes" do
           foo = nil
           subject.execute_controller mock_controller, lambda { |call| foo = call; latch.countdown! }
-          latch.wait(3).should be_true
+          latch.wait(LATCH_TIMEOUT).should be_true
           foo.should be subject
         end
 
         it "should prevent exceptions in controllers from being raised" do
           mock_controller.should_receive(:run).once.ordered.and_raise StandardError
           expect { subject.execute_controller mock_controller, lambda { |call| latch.countdown! } }.to_not raise_error
-          latch.wait(3).should be_true
+          latch.wait(LATCH_TIMEOUT).should be_true
           subject.alive?.should be true
         end
       end

--- a/spec/adhearsion/events_spec.rb
+++ b/spec/adhearsion/events_spec.rb
@@ -29,7 +29,7 @@ module Adhearsion
 
       Events.trigger :event, :foo
 
-      latch.wait(2).should be_true
+      latch.wait(LATCH_TIMEOUT).should be_true
       t.should be == :event
       o.should be == :foo
     end

--- a/spec/adhearsion/punchblock_plugin/initializer_spec.rb
+++ b/spec/adhearsion/punchblock_plugin/initializer_spec.rb
@@ -332,7 +332,7 @@ module Adhearsion
 
         Initializer.handle_event ami_event
 
-        latch.wait(1).should be true
+        latch.wait(LATCH_TIMEOUT).should be true
         result.should be ami_event
       end
     end

--- a/spec/adhearsion/router/openended_route_spec.rb
+++ b/spec/adhearsion/router/openended_route_spec.rb
@@ -27,7 +27,7 @@ module Adhearsion
           it "should accept the call" do
             call.should_receive(:accept).once
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           it "should instruct the call to use an instance of the controller" do
@@ -38,7 +38,7 @@ module Adhearsion
           it "should not hangup the call after all controllers have executed" do
             call.should_receive(:hangup).never
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
         end
 

--- a/spec/adhearsion/router/route_spec.rb
+++ b/spec/adhearsion/router/route_spec.rb
@@ -119,13 +119,13 @@ module Adhearsion
             Adhearsion::Events.should_receive(:trigger_immediately).once.with(:call_routed, call: call, route: route)
             call.should_receive(:hangup).once
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           it "should accept the call" do
             call.should_receive(:accept).once
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           it "should instruct the call to use an instance of the controller" do
@@ -136,7 +136,7 @@ module Adhearsion
           it "should hangup the call after all controllers have executed" do
             call.should_receive(:hangup).once
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           context "when the CallController mutates its metadata" do
@@ -165,7 +165,7 @@ module Adhearsion
             it "should not hangup the call after controller execution" do
               call.should_receive(:hangup).never
               route.dispatch call, lambda { latch.countdown! }
-              latch.wait(2).should be true
+              latch.wait(LATCH_TIMEOUT).should be true
             end
           end
 
@@ -175,7 +175,7 @@ module Adhearsion
             it "should not raise an exception" do
               lambda do
                 route.dispatch call, lambda { latch.countdown! }
-                latch.wait(2).should be true
+                latch.wait(LATCH_TIMEOUT).should be true
               end.should_not raise_error
             end
           end
@@ -192,7 +192,7 @@ module Adhearsion
             it "should not raise an exception" do
               lambda do
                 route.dispatch call, lambda { latch.countdown! }
-                latch.wait(2).should be true
+                latch.wait(LATCH_TIMEOUT).should be true
               end.should_not raise_error
             end
           end

--- a/spec/adhearsion/router/unaccepting_route_spec.rb
+++ b/spec/adhearsion/router/unaccepting_route_spec.rb
@@ -27,7 +27,7 @@ module Adhearsion
           it "should not accept the call" do
             call.should_receive(:accept).never
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           it "should instruct the call to use an instance of the controller" do
@@ -38,7 +38,7 @@ module Adhearsion
           it "should hangup the call after all controllers have executed" do
             call.should_receive(:hangup).once
             route.dispatch call, lambda { latch.countdown! }
-            latch.wait(2).should be true
+            latch.wait(LATCH_TIMEOUT).should be true
           end
 
           context "if hangup raises a Call::Hangup" do
@@ -47,7 +47,7 @@ module Adhearsion
             it "should not raise an exception" do
               lambda do
                 route.dispatch call, lambda { latch.countdown! }
-                latch.wait(2).should be true
+                latch.wait(LATCH_TIMEOUT).should be true
               end.should_not raise_error
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ Bundler.require(:default, :test) if defined?(Bundler)
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 
+LATCH_TIMEOUT = (ENV['LATCH_TIMEOUT'] || 3).to_i
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.mock_framework = :rspec


### PR DESCRIPTION
I had noticed that several of the Travis CI test runs that failed recently had done so incorrectly because a `latch.wait` returned false instead of true. I expect this is because the Travis build-bots are very loaded and so the latches don’t clear fast enough. This makes the default close to what the specs already were, but gives Travis a little extra time to get the specs done. I’m hopeful this will cut down on those annoying false-positives.

Note that I only did the latches expected to return true because I didn’t want any latches that were _supposed_ to stay latched to time out for other reasons.
