### PR TITLE
Get rid of autoload in favor of explicit requires

### DIFF
--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -2,35 +2,14 @@
 
 abort "ERROR: You are running Adhearsion on an unsupported version of Ruby (Ruby #{RUBY_VERSION} #{RUBY_RELEASE_DATE})! Please upgrade to at least Ruby v1.9.3, JRuby 1.7.0 or Rubinius 2.0." if RUBY_VERSION < "1.9.3"
 
-%w{
-  active_support/dependencies/autoload
+%w(
   punchblock
   celluloid
+).each { |r| require r }
 
-  adhearsion/version
-  adhearsion/foundation
-}.each { |f| require f }
 
 module Adhearsion
-  extend ActiveSupport::Autoload
-
   Error = Class.new StandardError
-
-  autoload :Call
-  autoload :CallController
-  autoload :Calls
-  autoload :Configuration
-  autoload :Console
-  autoload :Dispatcher
-  autoload :Events
-  autoload :Generators
-  autoload :Initializer
-  autoload :Logging
-  autoload :OutboundCall
-  autoload :Plugin
-  autoload :Process
-  autoload :Router
-  autoload :Statistics
 
   class << self
 
@@ -130,3 +109,22 @@ module Celluloid
     end
   end
 end
+
+%w(
+  version
+  foundation
+  call
+  call_controller
+  calls
+  configuration
+  console
+  events
+  generators
+  initializer
+  logging
+  outbound_call
+  plugin
+  process
+  router
+  statistics
+).each { |f| require "adhearsion/#{f}" }

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -4,6 +4,7 @@ require 'has_guarded_handlers'
 require 'thread'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'adhearsion'
 
 module Adhearsion
   ##

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -1,19 +1,17 @@
 # encoding: utf-8
 
 require 'countdownlatch'
-require 'active_support/dependencies/autoload'
+%w(
+  dial
+  input
+  menu_dsl
+  output
+  record
+  utility
+).each { |r| require "adhearsion/call_controller/#{r}" }
 
 module Adhearsion
   class CallController
-    extend ActiveSupport::Autoload
-
-    autoload :Dial
-    autoload :Input
-    autoload :MenuDSL
-    autoload :Output
-    autoload :Record
-    autoload :Utility
-
     include Dial
     include Input
     include Output

--- a/lib/adhearsion/call_controller/menu_dsl.rb
+++ b/lib/adhearsion/call_controller/menu_dsl.rb
@@ -1,23 +1,21 @@
 # encoding: utf-8
 
-require 'active_support/dependencies/autoload'
+%w(
+  calculated_match
+  calculated_match_collection
+  match_calculator
+  fixnum_match_calculator
+  range_match_calculator
+  string_match_calculator
+  array_match_calculator
+  menu_builder
+  menu
+).each { |r| require "adhearsion/call_controller/menu_dsl/#{r}" }
 
 module Adhearsion
   class CallController
     # @private
     module MenuDSL
-      extend ActiveSupport::Autoload
-
-      autoload :Exceptions
-      autoload :CalculatedMatch
-      autoload :CalculatedMatchCollection
-      autoload :MatchCalculator
-      autoload :FixnumMatchCalculator
-      autoload :RangeMatchCalculator
-      autoload :StringMatchCalculator
-      autoload :ArrayMatchCalculator
-      autoload :MenuBuilder
-      autoload :Menu
     end
   end
 end

--- a/lib/adhearsion/call_controller/menu_dsl/fixnum_match_calculator.rb
+++ b/lib/adhearsion/call_controller/menu_dsl/fixnum_match_calculator.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'adhearsion/call_controller/menu_dsl/string_match_calculator'
 
 module Adhearsion
   class CallController

--- a/lib/adhearsion/call_controller/output.rb
+++ b/lib/adhearsion/call_controller/output.rb
@@ -1,17 +1,14 @@
 # encoding: utf-8
-
-require 'active_support/dependencies/autoload'
+%w(
+  abstract_player
+  async_player
+  formatter
+  player
+).each { |r| require "adhearsion/call_controller/output/#{r}" }
 
 module Adhearsion
   class CallController
     module Output
-      extend ActiveSupport::Autoload
-
-      autoload :AbstractPlayer
-      autoload :AsyncPlayer
-      autoload :Formatter
-      autoload :Player
-
       PlaybackError = Class.new Adhearsion::Error # Represents failure to play audio, such as when the sound file cannot be found
       NoDocError = Class.new Adhearsion::Error # Represents failure to provide documents to playback
 

--- a/lib/adhearsion/generators.rb
+++ b/lib/adhearsion/generators.rb
@@ -1,13 +1,9 @@
 # encoding: utf-8
 
-require 'active_support/dependencies/autoload'
+require 'adhearsion/generators/generator'
 
 module Adhearsion
   module Generators
-    extend ActiveSupport::Autoload
-
-    autoload :Generator
-
     class << self
 
       # Show help message with available generators.

--- a/lib/adhearsion/plugin.rb
+++ b/lib/adhearsion/plugin.rb
@@ -2,7 +2,11 @@
 
 require 'loquacious'
 require 'active_support/inflector'
-require 'active_support/dependencies/autoload'
+require 'adhearsion/configuration'
+%w(
+  collection
+  initializer
+).each { |r| require "adhearsion/plugin/#{r}" }
 
 module Adhearsion
 
@@ -53,13 +57,7 @@ module Adhearsion
   #
   class Plugin
 
-    extend ActiveSupport::Autoload
-
     METHODS_OPTIONS = {:load => true, :scope => false}
-
-    autoload :Configuration
-    autoload :Collection
-    autoload :Initializer
 
     class << self
       ##

--- a/lib/adhearsion/punchblock_plugin.rb
+++ b/lib/adhearsion/punchblock_plugin.rb
@@ -1,13 +1,10 @@
 # encoding: utf-8
 
-require 'active_support/dependencies/autoload'
+require 'adhearsion/plugin'
+require 'adhearsion/punchblock_plugin/initializer'
 
 module Adhearsion
   class PunchblockPlugin < Plugin
-    extend ActiveSupport::Autoload
-
-    autoload :Initializer
-
     config :punchblock do
       enabled             true             , :transform => Proc.new { |v| v == 'true' }, :desc => "Enable or disable Punchblock connectivity to a Voice server"
       platform            :xmpp            , :transform => Proc.new { |v| v.to_sym }, :desc => <<-__

--- a/lib/adhearsion/punchblock_plugin/initializer.rb
+++ b/lib/adhearsion/punchblock_plugin/initializer.rb
@@ -4,7 +4,7 @@ require 'blather'
 require 'active_support/core_ext/class/attribute_accessors'
 
 module Adhearsion
-  class PunchblockPlugin
+  class PunchblockPlugin < Plugin
     class Initializer
       cattr_accessor :config, :client, :dispatcher, :attempts
 

--- a/lib/adhearsion/router.rb
+++ b/lib/adhearsion/router.rb
@@ -1,16 +1,14 @@
 # encoding: utf-8
 
-require 'active_support/dependencies/autoload'
+%w(
+  evented_route
+  openended_route
+  route
+  unaccepting_route
+).each { |r| require "adhearsion/router/#{r}" }
 
 module Adhearsion
   class Router
-    extend ActiveSupport::Autoload
-
-    autoload :EventedRoute
-    autoload :OpenendedRoute
-    autoload :Route
-    autoload :UnacceptingRoute
-
     NoMatchError = Class.new Adhearsion::Error
 
     attr_reader :routes

--- a/spec/support/initializer_stubs.rb
+++ b/spec/support/initializer_stubs.rb
@@ -2,7 +2,7 @@
 
 module InitializerStubs
   UNWANTED_BEHAVIOR = {
-    Adhearsion::Initializer => [:debugging_log, :initialize_log_paths, :update_rails_env_var, :require, :init_plugins, :run_plugins]
+    Adhearsion::Initializer => [:debugging_log, :initialize_log_paths, :update_rails_env_var, :require, :load, :init_plugins, :run_plugins]
   } unless defined? UNWANTED_BEHAVIOR
 
   def stub_behavior_for_initializer_with_no_path_changing_behavior


### PR DESCRIPTION
In past discussion we’ve come to the conclusion that autoloading isn’t adding anything to the code since we already explicitly tell the autoloader the dependencies to load. In addition, in many cases we have to eager-load. All that autoload is doing is slowing down the normal process of requiring files.

The immediate cause for this work was the fact that `require ‘adhearsion/rspec’` was failing because of autoloader failing to resolve a dependency between `Adhearsion::CallController` and `Adhearsion::CallController::Dial`.

Along the way this also fixed some other previously masked bugs:
- PunchblockPlugin was defined as inheriting from Plugin in one place and not another
- At least three classes never existed and were never referenced, but were made available via autoload:
  - Adhearsion::CallController::MenuDsl::Exceptions
  - Adhearsion::Dispatcher
  - Adhearsion::Plugin::Configuration
