### PR TITLE
[BUG] Ignore dead calls when searching by tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Feature: Ensure logging is available on STDOUT during RSpec runs
   * Feature: Reduce Adhearsion start-up time by selectively requiring the parts of ActiveSupport we use
   * Bugfix: Ensure config gets correctly loaded from config file
+  * Bugfix: Ignore dead calls when searching by tag
 
 # [2.5.3](https://github.com/adhearsion/adhearsion/compare/v2.5.2...v2.5.3) - [2014-04-25](https://rubygems.org/gems/adhearsion/versions/2.5.3)
   * Bugfix: Do not quiesce until the second SIGTERM, as per documentation ([#483](https://github.com/adhearsion/adhearsion/issues/483))

--- a/lib/adhearsion/calls.rb
+++ b/lib/adhearsion/calls.rb
@@ -38,7 +38,11 @@ module Adhearsion
 
     def with_tag(tag)
       values.find_all do |call|
-        call.tagged_with? tag
+        begin
+          call.tagged_with? tag
+        rescue Call::ExpiredError
+          false
+        end
       end
     end
 

--- a/spec/adhearsion/calls_spec.rb
+++ b/spec/adhearsion/calls_spec.rb
@@ -72,13 +72,25 @@ module Adhearsion
       end
     end
 
-    it "finding calls by a tag" do
-      calls.each { |call| subject << call }
+    context "tagged calls" do
+      it "finding calls by a tag" do
+        calls.each { |call| subject << call }
 
-      tagged_call = calls.last
-      tagged_call.tag :moderator
+        tagged_call = calls.last
+        tagged_call.tag :moderator
 
-      subject.with_tag(:moderator).should be == [tagged_call]
+        subject.with_tag(:moderator).should be == [tagged_call]
+      end
+
+      it "when a call is dead, ignore it in the search" do
+        calls.each { |call| subject << call }
+
+        tagged_call = calls.last
+        tagged_call.tag :moderator
+        Celluloid::Actor.kill tagged_call
+
+        subject.with_tag(:moderator).should be == []
+      end
     end
 
     it "finding calls by uri" do


### PR DESCRIPTION
This fixes an issue with Calls#with_tag raising exceptions when searching a collection that includes dead tags that have not yet been cleaned up by the supervisor.
