### PR TITLE
use AHN_PLATFORM_ENVIRONMENT as default when AHN_ENV is not present

### DIFF
--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -60,7 +60,7 @@ module Adhearsion
     end
 
     def environment
-      ENV['AHN_ENV'] || ENV['RAILS_ENV'] || :development
+      ENV['AHN_ENV'] || ENV['RAILS_ENV'] || ENV['AHN_PLATFORM_ENVIRONMENT'] || :development
     end
 
     def environments

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -57,7 +57,9 @@ module Adhearsion
         puts  "You tried to initialize with an invalid environment name #{env}; environment-specific config may not load successfully. Valid values are #{_config.valid_environments}."
         env = nil
       end
-      _config.platform.environment = env if env
+      if env && !_config.platform.environment
+        _config.platform.environment = env
+      end
       _config
     end
 

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -38,8 +38,10 @@ module Adhearsion
     end
 
     def config(&block)
+      return @config if @config
+
       @config ||= initialize_config
-      block_given? and yield @config
+      yield(@config) if block_given?
       @config
     end
 

--- a/lib/adhearsion/configuration.rb
+++ b/lib/adhearsion/configuration.rb
@@ -31,7 +31,7 @@ module Adhearsion
           want these files to be loaded. This folder is relative to the application root folder.
         __
 
-        environment :development, :transform => Proc.new { |v| v.to_sym }, :desc => <<-__
+        environment nil, :transform => Proc.new { |v| v.to_sym }, :desc => <<-__
           Active environment. Supported values: development, production, staging, test
         __
 

--- a/spec/adhearsion_spec.rb
+++ b/spec/adhearsion_spec.rb
@@ -55,6 +55,19 @@ describe Adhearsion do
     end
   end
 
+  describe "#environment" do
+    let(:env) { "foo" }
+
+    before do
+      Adhearsion.config{ |conf| conf.platform.environment = nil}
+      ENV['AHN_PLATFORM_ENVIRONMENT'] = env
+    end
+
+    it "should be the collection of valid environments" do
+      Adhearsion.config.platform.environment.should eq env.to_sym
+    end
+  end
+
   describe "#router" do
     its(:router) { should be_a Adhearsion::Router }
 


### PR DESCRIPTION
Not sure it's an issue, but this made sens to me. What do you guys think about it? 