### PR TITLE
Adding a Hash subclass to call variables turns it into a ActiveSupport::HashWithIndifferentAccess

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ffi', ["~> 1.0"]
   s.add_runtime_dependency 'girl_friday'
   s.add_runtime_dependency 'has-guarded-handlers', ["~> 1.6"]
+  s.add_runtime_dependency 'hashie', ["~> 3.0"]
   s.add_runtime_dependency 'jruby-openssl' if RUBY_PLATFORM == 'java'
   s.add_runtime_dependency 'logging', ["~> 1.8"]
   s.add_runtime_dependency 'pry'

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -2,8 +2,7 @@
 
 require 'has_guarded_handlers'
 require 'thread'
-require 'active_support/hash_with_indifferent_access'
-require 'active_support/core_ext/hash/indifferent_access'
+require 'hashie'
 require 'adhearsion'
 
 module Adhearsion
@@ -15,6 +14,10 @@ module Adhearsion
     Hangup          = Class.new Adhearsion::Error
     CommandTimeout  = Class.new Adhearsion::Error
     ExpiredError    = Class.new Celluloid::DeadActorError
+
+    class VariablesCollection < Hash
+      include Hashie::Extensions::IndifferentAccess
+    end
 
     include Celluloid
     include HasGuardedHandlers
@@ -76,7 +79,7 @@ module Adhearsion
       @offer        = nil
       @tags         = []
       @commands     = CommandRegistry.new
-      @variables    = HashWithIndifferentAccess.new
+      @variables    = VariablesCollection.new
       @controllers  = []
       @end_reason   = nil
       @end_code     = nil


### PR DESCRIPTION
I was using Hashie to parse some JSON, and when I stored the result into call variables (using call[:menu]) it got converted to a ActiveSupport::HashWithIndifferentAccess, losing the accessor methods.
