### PR TITLE
Feature: Logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Bugfix: Logging around post-routing call termination now accounts for the call already being down.
   * Bugfix: Bubble component complete events to other registered handlers
   * Bugfix: Calling `ahn restart` on a stopped application now works
+  * Documentation: Improved INFO level log messages
 
 # [2.5.4](https://github.com/adhearsion/adhearsion/compare/v2.5.3...v2.5.4) - [2014-07-18](https://rubygems.org/gems/adhearsion/versions/2.5.4)
   * Bugfix: Ignore dead calls when searching by tag

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -232,7 +232,7 @@ module Adhearsion
       end
 
       on_end do |event|
-        logger.info "Call ended due to #{event.reason}"
+        logger.info "Call #{from} -> #{to} ended due to #{event.reason}#{" (code #{event.platform_code})" if event.platform_code}"
         @end_time = event.timestamp.to_time
         @duration = @end_time - @start_time if @start_time
         clear_from_active_calls

--- a/lib/adhearsion/initializer.rb
+++ b/lib/adhearsion/initializer.rb
@@ -163,10 +163,10 @@ module Adhearsion
         logger.info "Received SIG#{signal}. Shutting down."
         Adhearsion::Process.shutdown
       when 'HUP'
-        logger.debug "Received SIGHUP. Reopening logfiles."
+        logger.info "Received SIGHUP. Reopening logfiles."
         Adhearsion::Logging.reopen_logs
       when 'ALRM'
-        logger.debug "Received SIGALRM. Toggling trace logging."
+        logger.info "Received SIGALRM. Toggling trace logging."
         Adhearsion::Logging.toggle_trace!
       when 'ABRT'
         logger.info "Received ABRT signal. Forcing stop."


### PR DESCRIPTION
I took a look at all the places we used `logger.info` to make sure the messages contained useful information. This is important because INFO is the default level for production apps.
