### PR TITLE
[CS] Invoke pre_join callback with #call instead of #[]

### DIFF
--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -396,7 +396,7 @@ module Adhearsion
         end
 
         def pre_join_tasks(call)
-          @pre_join[call] if @pre_join
+          @pre_join.call(call) if @pre_join
           terminate_ringback
         end
 


### PR DESCRIPTION
Generally it seems like procs are invoked with `#call` in Adhearsion, and as such, the `#[]` threw me off when I was figuring out some `pre_join`-related logic.

As far as I can tell, there is no reason for using `#[]`, and so consistency should be favored.
