### PR TITLE
Allow overriding of Adhearsion.config.platform.after_hangup_lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Feature: Call#after_hangup_lifetime optionally overrides Adhearsion.config.platform.after_hangup_lifetime 
   * Feature: Accept a `:cleanup` parameter in Dial options, which specifies a controller to be run on each outbound call before cleanup.
   * Feature: Add a per-controller callback `on_error` that is invoked whenever an unhandled exception is raised. This can be used to play apology messages before disconnecting the caller ([#486](https://github.com/adhearsion/adhearsion/issues/486))
   * Feature: Add `Call#redirect` and `CallController#redirect` for redirecting calls to other systems ([#465](https://github.com/adhearsion/adhearsion/issues/465))

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -50,8 +50,11 @@ module Adhearsion
     # @return [Time] the time at which the call began. For inbound calls this is the time at which the call was offered to Adhearsion. For outbound calls it is the time at which the remote party answered.
     attr_reader :end_time
 
-    # @return [true, false] wether or not the call should be automatically hung up after executing its controller
+    # @return [true, false] whether or not the call should be automatically hung up after executing its controller
     attr_accessor :auto_hangup
+
+    # @return [Integer] the number of seconds after the call is hung up that the controller will remain active
+    attr_accessor :after_hangup_lifetime
 
     delegate :[], :[]=, :to => :variables
 
@@ -84,6 +87,7 @@ module Adhearsion
       @peers        = {}
       @duration     = nil
       @auto_hangup  = true
+      @after_hangup_lifetime = nil
 
       self << offer if offer
     end
@@ -240,7 +244,7 @@ module Adhearsion
         @end_code = event.platform_code
         @end_blocker.broadcast event.reason
         @commands.terminate
-        after(Adhearsion.config.platform.after_hangup_lifetime) { terminate }
+        after(@after_hangup_lifetime || Adhearsion.config.platform.after_hangup_lifetime) { terminate }
       end
     end
 

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -96,6 +96,11 @@ module Adhearsion
       it { is_expected.to be_truthy }
     end
 
+    describe '#after_hangup_lifetime' do
+      subject { super().after_hangup_lifetime }
+      it { is_expected.to eq(nil) }
+    end
+
     context "when the ID is nil" do
       let(:call_id) { nil }
 
@@ -614,8 +619,16 @@ module Adhearsion
           expect(Adhearsion.active_calls.size).to eq(size_before)
         end
 
-        it "shuts down the actor" do
+        it "shuts down the actor using platform config" do
           Adhearsion.config.platform.after_hangup_lifetime = 2
+          subject << end_event
+          sleep 2.1
+          expect(subject.alive?).to be false
+          expect { subject.id }.to raise_error Call::ExpiredError, /expired and is no longer accessible/
+        end
+
+        it "shuts down the actor using the call after_hangup_lifetime instance" do
+          subject.after_hangup_lifetime = 2
           subject << end_event
           sleep 2.1
           expect(subject.alive?).to be false


### PR DESCRIPTION
Short and sweet: this adds and allows for a `Call#after_hangup_lifetime` to be set,  in order to facilitate an arbitrary after-hangup call lifetime.

A use case would be if we are dialing out and the calling party hangs up, but we still want the far-side to be allowed to answer. That ringing period may be longer than the lower (more-performance related) default `Adhearsion.config.platform.after_hangup_lifetime` 