### PR TITLE
use an ActorProxy (subclass) instead of a method_missing definition

### DIFF
--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -16,21 +16,22 @@ module Adhearsion
     CommandTimeout  = Class.new Adhearsion::Error
     ExpiredError    = Class.new Celluloid::DeadActorError
 
+    # @private
+    class ActorProxy < Celluloid::ActorProxy
+      def method_missing(meth, *args, &block)
+        super(meth, *args, &block)
+      rescue ::Celluloid::DeadActorError
+        raise ExpiredError, "This call is expired and is no longer accessible. See http://adhearsion.com/docs/calls for further details."
+      end
+    end
+
     include Celluloid
     include HasGuardedHandlers
 
+    proxy_class Call::ActorProxy
+
     execute_block_on_receiver :register_handler, :register_tmp_handler, :register_handler_with_priority, :register_handler_with_options, :register_event_handler, :on_joined, :on_unjoined, :on_end, :execute_controller, *execute_block_on_receiver
     finalizer :finalize
-
-    def self.new(*args, &block)
-      super.tap do |proxy|
-        def proxy.method_missing(*args)
-          super
-        rescue Celluloid::DeadActorError
-          raise ExpiredError, "This call is expired and is no longer accessible. See http://adhearsion.com/docs/calls for further details."
-        end
-      end
-    end
 
     # @return [Symbol] the reason for the call ending
     attr_reader :end_reason


### PR DESCRIPTION
... on every `Call.new`

some micro-benchmarks (run against an older AHN version and JRuby 1.7.4): https://gist.github.com/kares/3576e272250204eb66d1

with 1000 calls we're getting **~ 37%** improvement, while with 500 around **33%**