### PR TITLE
Permit timing out when calling `Call#wait_for_end`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Change: Rename "platform" to "core" relating to the config system, because "platform" is overloaded. Settings are now `config.core.*` or `AHN_CORE_*`.
   * Feature: Add i18n support via `CallController#t`
   * Feature: Integrate a Rack-based HTTP server from the Virginia plugin
+  * Feature: Permit timing out when calling `Call#wait_for_end`
   * Upgrade to Celluloid 0.16
   * Move events system to Celluloid and do away with GirlFriday
 

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -160,14 +160,18 @@ module Adhearsion
 
     #
     # Wait for the call to end. Returns immediately if the call has already ended, else blocks until it does so.
+    # @param [Integer, nil] timeout a timeout after which to unblock, returning `:timeout`
     # @return [Symbol] the reason for the call ending
+    # @raises [Celluloid::ConditionError] in case of a specified timeout expiring
     #
-    def wait_for_end
+    def wait_for_end(timeout = nil)
       if end_reason
         end_reason
       else
-        @end_blocker.wait
+        @end_blocker.wait(timeout)
       end
+    rescue Celluloid::ConditionError => e
+      abort e
     end
 
     #

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -685,6 +685,18 @@ module Adhearsion
 
           expect(fut.value).to eq(:hangup)
         end
+
+        it "should unblock after a timeout" do
+          fut = subject.future.wait_for_end 1
+
+          sleep 0.5
+          expect(fut).not_to be_ready
+
+          sleep 0.5
+
+          expect { fut.value }.to raise_error(Celluloid::ConditionError)
+          expect(subject.alive?).to be(true)
+        end
       end
     end
 


### PR DESCRIPTION
Requires https://github.com/celluloid/celluloid/pull/344 from Celluloid 0.16