### PR TITLE
Define configuration per-environment for any environment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * Change: Ruby 1.9 is no longer supported. Minimum supported versions are Ruby 2.2.0 and JRuby 9.0.0.0
   * Change: Rename "platform" to "core" relating to the config system, because "platform" is overloaded. Settings are now `config.core.*` or `AHN_CORE_*`.
   * Change: Permit application environment to be set only by AHN_ENV. The config system depends on the environment, and the previous dependency was circular.
+  * Change: Define configuration per-environment for any environment name and without colliding with plugin names. See [#442](https://github.com/adhearsion/adhearsion/issues/442). Syntax is now `config.env(:development).foo = :bar` instead of `config.development.foo = :bar`.
   * Feature: Add i18n support via `CallController#t`
   * Feature: Integrate a Rack-based HTTP server from the Virginia plugin
   * Feature: Permit timing out when calling `Call#wait_for_end`

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -47,10 +47,6 @@ module Adhearsion
       @environment = other ? other.to_sym : other
     end
 
-    def environments
-      config.valid_environments
-    end
-
     def config=(config)
       @config = config
     end

--- a/lib/adhearsion/generators/app/templates/adhearsion.erb
+++ b/lib/adhearsion/generators/app/templates/adhearsion.erb
@@ -17,8 +17,8 @@ Adhearsion.config do |config|
   #          config.<plugin-name>.<key> = <value>
   #        end
 <% end %>
-  config.development do |dev|
-    dev.core.logging.level = :debug
+  config.env :development do
+    config.core.logging.level = :debug
   end
 
   ##

--- a/spec/adhearsion/configuration_spec.rb
+++ b/spec/adhearsion/configuration_spec.rb
@@ -98,17 +98,17 @@ describe Adhearsion::Configuration do
       end
 
       before do
-        subject.production do |env|
-          env.core.my_level = 0
+        subject.env :production do
+          subject.core.my_level = 0
         end
-        subject.development do |env|
-          env.core.my_level = 1
+        subject.env :development do
+          subject.core.my_level = 1
         end
-        subject.staging do |env|
-          env.core.my_level = 2
+        subject.env :staging do
+          subject.core.my_level = 2
         end
-        subject.test do |env|
-          env.core.my_level = 3
+        subject.env :test do
+          subject.core.my_level = 3
         end
       end
 
@@ -131,31 +131,6 @@ describe Adhearsion::Configuration do
         end
       end
     end
-  end
-
-  describe "while defining the environment" do
-
-    before do
-      Adhearsion.config = nil
-    end
-
-    after do
-      Adhearsion.environment = nil
-      Adhearsion.config = nil
-    end
-
-    [:development, :production, :staging, :test].each do |env|
-      it "should respond to #{env}" do
-        expect(Adhearsion.config).to respond_to(env)
-      end
-    end
-
-    it "should allow to add a new environment" do
-      expect(Adhearsion.config.valid_environment?(:another_environment)).to eq(false)
-      Adhearsion.environments << :another_environment
-      expect(Adhearsion.config.valid_environment?(:another_environment)).to eq(true)
-    end
-
   end
 
   describe "while retrieving configuration descriptions" do
@@ -222,17 +197,17 @@ describe Adhearsion::Configuration do
           end
 
           before do
-            config.production do |env|
-              env.my_plugin.name = "production"
+            config.env :production do
+              config.my_plugin.name = "production"
             end
-            config.development do |env|
-              env.my_plugin.name = "development"
+            config.env :development do
+              config.my_plugin.name = "development"
             end
-            config.staging do |env|
-              env.my_plugin.name = "staging"
+            config.env :staging do
+              config.my_plugin.name = "staging"
             end
-            config.test do |env|
-              env.my_plugin.name = "test"
+            config.env :test do
+              config.my_plugin.name = "test"
             end
           end
 

--- a/spec/adhearsion_spec.rb
+++ b/spec/adhearsion_spec.rb
@@ -36,13 +36,6 @@ describe Adhearsion do
     end
   end
 
-  describe "#environments" do
-    it "should be the collection of valid environments" do
-      Adhearsion.config.valid_environments << :foo
-      expect(Adhearsion.environments).to include :foo
-    end
-  end
-
   describe "#router" do
     describe '#router' do
       subject { super().router }


### PR DESCRIPTION
...and without colliding with plugin names. See [#442](https://github.com/adhearsion/adhearsion/issues/442). Syntax is now `config.env(:development).foo = :bar` instead of `config.development.foo = :bar`.