### PR TITLE
Fixes a memory leak issue caused by Adhearsion::Translator::Asterisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Bugfix: Ensure components are deregistered from asterisk translator once the call is ended ([#582](https://github.com/adhearsion/adhearsion/pull/582))
   * Change: Define configuration per-environment for any environment name and without colliding with plugin names. See [#442](https://github.com/adhearsion/adhearsion/issues/442). Syntax is now `config.env(:development).foo = :bar` instead of `config.development.foo = :bar`.
   * Feature: Introduce the concept of application specific config. Similar to a plugin, an Application can specify config and an initialiser, and is the place to put such application-wide and unshareable things.
 

--- a/lib/adhearsion/translator/asterisk.rb
+++ b/lib/adhearsion/translator/asterisk.rb
@@ -70,6 +70,10 @@ module Adhearsion
         @components[component.id] ||= component
       end
 
+      def deregister_component(id)
+        @components.delete id
+      end
+
       def component_with_id(component_id)
         @components[component_id]
       end

--- a/lib/adhearsion/translator/asterisk/component.rb
+++ b/lib/adhearsion/translator/asterisk/component.rb
@@ -28,6 +28,7 @@ module Adhearsion
             event = Adhearsion::Event::Complete.new reason: reason, recording: recording
             send_event event
             call.deregister_component id if call
+            translator.deregister_component id
           end
 
           def send_event(event)

--- a/spec/adhearsion/translator/asterisk/component_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component_spec.rb
@@ -58,6 +58,15 @@ module Adhearsion
               expect(subject).to receive(:send_complete_event).once.with Adhearsion::Event::Complete::Hangup.new
               subject.call_ended
             end
+
+            it "should deregister component from translator" do
+              translator.register_component(subject)
+              expect(translator.component_with_id(subject.id)).not_to be nil
+              expect(translator).to receive(:handle_pb_event).once
+              subject.call_ended
+              expect(translator.component_with_id(subject.id)).to be nil
+            end
+
           end
 
           describe '#execute_command' do


### PR DESCRIPTION
Ensure the components are deregistered from Adhearsion::Translator::Asterisk
once the call is ended. For more details see

https://github.com/adhearsion/punchblock/pull/250