### PR TITLE
[feature] Trigger an event when events are received for Inactive calls

### DIFF
--- a/lib/adhearsion/rayo/initializer.rb
+++ b/lib/adhearsion/rayo/initializer.rb
@@ -148,6 +148,7 @@ module Adhearsion
             call.async.deliver_message event
           else
             logger.warn "Event received for inactive call #{event.target_call_id}: #{event.inspect}"
+            Events.trigger :inactive_call, event
           end
         end
 

--- a/spec/adhearsion/rayo/initializer_spec.rb
+++ b/spec/adhearsion/rayo/initializer_spec.rb
@@ -296,6 +296,11 @@ describe Adhearsion::Rayo::Initializer do
         expect(Adhearsion::Logging.get_logger(described_class)).to receive(:warn).once.with("Event received for inactive call #{call_id}: #{mock_event.inspect}")
         described_class.dispatch_call_event mock_event
       end
+
+      it "should trigger an inactive call event" do
+        expect(Adhearsion::Events).to receive(:trigger).once.with(:inactive_call, mock_event)
+        described_class.dispatch_call_event mock_event
+      end
     end
 
     describe "when the registry contains a dead call" do


### PR DESCRIPTION
We found it useful for monitoring/alerting whenever an event is received for an inactive call. This adds a new event that is triggered for handling that scenario.
