### PR TITLE
Add a unique ID to Rayo resource identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Change: Add a short UUID to the Rayo resource identifier to prevent possible PID conflicts made more likely by containerization  
   * Bugfix: Ensure components are deregistered from asterisk translator once the call is ended ([#582](https://github.com/adhearsion/adhearsion/pull/582))
   * Change: Define configuration per-environment for any environment name and without colliding with plugin names. See [#442](https://github.com/adhearsion/adhearsion/issues/442). Syntax is now `config.env(:development).foo = :bar` instead of `config.development.foo = :bar`.
   * Feature: Introduce the concept of application specific config. Similar to a plugin, an Application can specify config and an initialiser, and is the place to put such application-wide and unshareable things.

--- a/lib/adhearsion/rayo/initializer.rb
+++ b/lib/adhearsion/rayo/initializer.rb
@@ -2,6 +2,7 @@
 
 require 'blather'
 require 'active_support/core_ext/class/attribute_accessors'
+require 'securerandom'
 
 module Adhearsion
   module Rayo
@@ -161,7 +162,7 @@ module Adhearsion
         end
 
         def resource
-          [machine_identifier, ::Process.pid].join '-'
+          [machine_identifier, ::Process.pid, SecureRandom.hex(3)].join '-'
         end
 
         def machine_identifier

--- a/spec/adhearsion/rayo/initializer_spec.rb
+++ b/spec/adhearsion/rayo/initializer_spec.rb
@@ -51,6 +51,7 @@ describe Adhearsion::Rayo::Initializer do
     Adhearsion::Events.refresh!
     allow(Adhearsion::Process).to receive_messages :fqdn => 'hostname'
     allow(::Process).to receive_messages :pid => 1234
+    allow(SecureRandom).to receive_messages :hex => 'abc123'
   end
 
   describe "starts the client with the default values" do
@@ -90,7 +91,7 @@ describe Adhearsion::Rayo::Initializer do
   end
 
   it "starts the client with the correct resource" do
-    username = "usera@127.0.0.1/hostname-1234"
+    username = "usera@127.0.0.1/hostname-1234-abc123"
 
     expect(Adhearsion::Rayo::Connection::XMPP).to receive(:new).once.with(hash_including :username => username).and_return mock_client
     initialize_rayo
@@ -100,8 +101,9 @@ describe Adhearsion::Rayo::Initializer do
     it "should use the local hostname instead" do
       allow(Adhearsion::Process).to receive(:fqdn).and_raise SocketError
       allow(Socket).to receive(:gethostname).and_return 'local_hostname'
+      allow(SecureRandom).to receive(:hex).and_return 'fed987'
 
-      username = "usera@127.0.0.1/local_hostname-1234"
+      username = "usera@127.0.0.1/local_hostname-1234-fed987"
 
       expect(Adhearsion::Rayo::Connection::XMPP).to receive(:new).once.with(hash_including :username => username).and_return mock_client
       initialize_rayo


### PR DESCRIPTION
The current identifier uses the PID for uniqueness, but this isn't enough under certain conditions - for example, when containerizing Adhearsion. 

If the machine name is the same across containers (e.g. by using `--net=host` on Docker) and Adhearsion is the only process running in each container, the likelyhood of a PID conflict is quite high (as the PIDs assigned to a process inside a container start from 1 again and so are usually quite low -- < 10.)