### PR TITLE
Only log the new controller class name

### DIFF
--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -541,7 +541,7 @@ module Adhearsion
     def execute_controller(controller = nil, completion_callback = nil, &block)
       raise ArgumentError, "Cannot supply a controller and a block at the same time" if controller && block_given?
       controller ||= CallController.new current_actor, &block
-      logger.info "Executing controller #{controller.inspect}"
+      logger.info "Executing controller #{controller.class}"
       controller.bg_exec completion_callback
     end
 

--- a/lib/adhearsion/call_controller/input/result.rb
+++ b/lib/adhearsion/call_controller/input/result.rb
@@ -9,7 +9,7 @@ module Adhearsion
         end
 
         def inspect
-          "#<#{self.class} status=#{status.inspect}, confidence=#{confidence.inspect}, utterance=#{utterance.inspect}, interpretation=#{interpretation.inspect}, nlsml=#{nlsml.inspect}>"
+          "#<#{self.class} status=#{status.inspect}, confidence=#{confidence.inspect}, utterance=#{utterance.inspect}, interpretation=#{interpretation.inspect}, nlsml='#{nlsml.to_xml.split("\n").join(' ')}'>"
         end
 
         def utterance=(other)


### PR DESCRIPTION
Reference #563

These messages are printed at INFO level, and so should be more succinct. What we really care about is which controller is being invoked. Since the controller instances often include a large amount of metadata, these lines are often responsible for an unreasonable amount of log noise (due to the `#inspect`).