### PR TITLE
Stopping playback via `ControlPlayback` on newer Asterisk versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Bugfix: Use `ControlPlayback` rather than redirecting to terminate `Playback` on newer versions of Asterisk ([#593](https://github.com/adhearsion/adhearsion/issues/593))
   * Bugfix: Ensure components are deregistered from asterisk translator once the call is ended ([#582](https://github.com/adhearsion/adhearsion/pull/582))
   * Change: Define configuration per-environment for any environment name and without colliding with plugin names. See [#442](https://github.com/adhearsion/adhearsion/issues/442). Syntax is now `config.env(:development).foo = :bar` instead of `config.development.foo = :bar`.
   * Feature: Introduce the concept of application specific config. Similar to a plugin, an Application can specify config and an initialiser, and is the place to put such application-wide and unshareable things.

--- a/lib/adhearsion/translator/asterisk/component.rb
+++ b/lib/adhearsion/translator/asterisk/component.rb
@@ -85,5 +85,5 @@ end
   mrcp_prompt
   mrcp_native_prompt
   record
-  stop_by_redirect
+  stop_playback
 }.each { |component| require "adhearsion/translator/asterisk/component/#{component}" }

--- a/lib/adhearsion/translator/asterisk/component/composed_prompt.rb
+++ b/lib/adhearsion/translator/asterisk/component/composed_prompt.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 require 'adhearsion/translator/asterisk/component/input_component'
-require 'adhearsion/translator/asterisk/component/stop_by_redirect'
+require 'adhearsion/translator/asterisk/component/stop_playback'
 
 module Adhearsion
   module Translator
@@ -9,7 +9,7 @@ module Adhearsion
       module Component
         class ComposedPrompt < Component
           include InputComponent
-          include StopByRedirect
+          include StopPlayback
 
           def execute
             validate
@@ -44,7 +44,7 @@ module Adhearsion
 
           def process_dtmf(digit)
             if @component_node.barge_in && @output_incomplete
-              @output_component.stop_by_redirect Adhearsion::Event::Complete::Stop.new
+              @output_component.stop_playback Adhearsion::Event::Complete::Stop.new
               @barged = true
             end
             super

--- a/lib/adhearsion/translator/asterisk/component/mrcp_native_prompt.rb
+++ b/lib/adhearsion/translator/asterisk/component/mrcp_native_prompt.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'adhearsion/translator/asterisk/component/stop_by_redirect'
+require 'adhearsion/translator/asterisk/component/stop_playback'
 require 'adhearsion/translator/asterisk/component/mrcp_recog_prompt'
 
 module Adhearsion
@@ -8,7 +8,7 @@ module Adhearsion
     class Asterisk
       module Component
         class MRCPNativePrompt < Component
-          include StopByRedirect
+          include StopPlayback
           include MRCPRecogPrompt
 
           private

--- a/lib/adhearsion/translator/asterisk/component/mrcp_prompt.rb
+++ b/lib/adhearsion/translator/asterisk/component/mrcp_prompt.rb
@@ -7,7 +7,7 @@ module Adhearsion
     class Asterisk
       module Component
         class MRCPPrompt < Component
-          include StopByRedirect
+          include StopPlayback
           include MRCPRecogPrompt
 
           private

--- a/lib/adhearsion/translator/asterisk/component/output.rb
+++ b/lib/adhearsion/translator/asterisk/component/output.rb
@@ -9,7 +9,7 @@ module Adhearsion
     class Asterisk
       module Component
         class Output < Component
-          include StopByRedirect
+          include StopPlayback
 
           UnrenderableDocError  = Class.new OptionError
           UniMRCPError          = Class.new Error
@@ -89,14 +89,9 @@ module Adhearsion
             with_error 'option error', e.message
           end
 
-          def stop_by_redirect(complete_reason)
+          def stop_playback(complete_reason)
             @stopped = true
-            if ami_version >= "2.0.0"
-              @call.stop_playback
-              send_complete_event complete_reason
-            else
-              super
-            end
+            super
           end
 
           private
@@ -114,7 +109,7 @@ module Adhearsion
 
             if interrupt
               call.register_handler :ami, [{:name => 'DTMF', [:[], 'End'] => 'Yes'}, {:name => 'DTMFEnd'}] do |event|
-                stop_by_redirect finish_reason
+                stop_playback finish_reason
               end
             end
 

--- a/lib/adhearsion/translator/asterisk/component/stop_playback.rb
+++ b/lib/adhearsion/translator/asterisk/component/stop_playback.rb
@@ -6,16 +6,27 @@ module Adhearsion
   module Translator
     class Asterisk
       module Component
-        module StopByRedirect
+        module StopPlayback
           def execute_command(command)
             return super unless command.is_a?(Adhearsion::Rayo::Component::Stop)
             if @complete
               command.response = Adhearsion::ProtocolError.new.setup 'component-already-stopped', "Component #{id} is already stopped", call_id, id
             else
-              stop_by_redirect Adhearsion::Event::Complete::Stop.new
+              stop_playback Adhearsion::Event::Complete::Stop.new
               command.response = true
             end
           end
+
+          def stop_playback(complete_reason)
+            if ami_client.version.to_s >= '2.0'
+              @call.stop_playback
+              send_complete_event complete_reason
+            else
+              stop_by_redirect complete_reason
+            end
+          end
+
+        protected
 
           def stop_by_redirect(complete_reason)
             call.register_handler :ami, [{name: 'AsyncAGI', [:[], 'SubEvent'] => 'Start'}, {name: 'AsyncAGIStart'}] do |event|

--- a/spec/adhearsion/translator/asterisk/component/composed_prompt_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component/composed_prompt_spec.rb
@@ -71,6 +71,8 @@ module Adhearsion
           let(:playbackstatus) { 'SUCCESS' }
 
           before do
+            allow(ami_client).to receive(:version)
+
             allow(call).to receive_messages answered?: true, execute_agi_command: true
             allow(call).to receive(:channel_var).with('PLAYBACKSTATUS').and_return playbackstatus
             original_command.request!

--- a/spec/adhearsion/translator/asterisk/component/mrcp_native_prompt_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component/mrcp_native_prompt_spec.rb
@@ -85,6 +85,8 @@ module Adhearsion
           subject { described_class.new original_command, mock_call }
 
           before do
+            allow(ami_client).to receive(:version)
+
             original_command.request!
             {
               'RECOG_STATUS' => recog_status,

--- a/spec/adhearsion/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -82,6 +82,8 @@ module Adhearsion
           subject { described_class.new original_command, mock_call }
 
           before do
+            allow(ami_client).to receive(:version)
+
             original_command.request!
             {
               'RECOG_STATUS' => recog_status,

--- a/spec/adhearsion/translator/asterisk/component/output_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component/output_spec.rb
@@ -45,6 +45,10 @@ module Adhearsion
             }.and_return code: 200, result: 1
           end
 
+          before do
+            allow(ami_client).to receive(:version)
+          end
+
           describe '#execute' do
             before { original_command.request! }
 

--- a/spec/adhearsion/translator/asterisk/component/stop_playback_spec.rb
+++ b/spec/adhearsion/translator/asterisk/component/stop_playback_spec.rb
@@ -6,10 +6,10 @@ module Adhearsion
   module Translator
     class Asterisk
       module Component
-        describe StopByRedirect do
+        describe StopPlayback do
 
           class MockComponent < Component
-            include StopByRedirect
+            include StopPlayback
             def set_complete
               @complete = true
             end
@@ -52,6 +52,34 @@ module Adhearsion
                 subject.set_complete
                 subject.execute_command command
                 expect(command.response(0.1)).to be_a Adhearsion::ProtocolError
+              end
+
+              context "in AMI 2.0 or greater" do
+                [ '2.0', '2.0.1', '3.0' ].each do |version|
+                  before do
+                    allow(ami_client).to receive(:version) { version }
+                    allow(translator).to receive :handle_pb_event
+                  end
+                end
+
+                it 'stops playback by executing a ControlPlayback action' do
+                  expect(ami_client).to receive(:send_action).once.with('ControlPlayback',
+                    'Control' => 'stop',
+                    'Channel' => 'SIP/foo'
+                  )
+                  subject.execute_command command
+                end
+              end
+
+              context "in AMI < 2.0" do
+                before do
+                  allow(ami_client).to receive(:version) { '1.4' }
+                end
+
+                it 'stops playback through redirection' do
+                  expect(ami_client).to receive(:send_action).once.with('Redirect', hash_including('Channel' => 'SIP/foo'))
+                  subject.execute_command command
+                end
               end
             end
           end


### PR DESCRIPTION
Use `ControlPlayback` rather than redirecting to terminate `Playback` on
newer versions of Asterisk. Since this can be expected to be the
preferred practice going forward, the makeshift `StopByRedirect`
mechanism (component) has been changed to the more appropriate (if
generic) `StopPlayback`.

Addresses #593 Redirecting to terminate Playback on Asterisk 13 causes
exceptions