### PR TITLE
Reporting statistics should not deadlock call processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [develop](https://github.com/adhearsion/adhearsion)
   * Bugfix: Handle more AMI error responses which mean the channel is not found
   * Bugfix: Reporting statistics should not deadlock call processing
+  * Bugfix: Sending the `USR1` signal to an Adhearsion application now prints thread stack traces to STDERR.
 
 # [3.0.0.rc1](https://github.com/adhearsion/adhearsion/compare/v3.0.0.beta2...v3.0.0.rc1) - [2016-01-07](https://rubygems.org/gems/adhearsion/versions/3.0.0.rc1)
   * Bugfix: Concurrent access to call collection should not be permitted. See [#589](https://github.com/adhearsion/adhearsion/issues/589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/adhearsion)
   * Bugfix: Handle more AMI error responses which mean the channel is not found
+  * Bugfix: Reporting statistics should not deadlock call processing
 
 # [3.0.0.rc1](https://github.com/adhearsion/adhearsion/compare/v3.0.0.beta2...v3.0.0.rc1) - [2016-01-07](https://rubygems.org/gems/adhearsion/versions/3.0.0.rc1)
   * Bugfix: Concurrent access to call collection should not be permitted. See [#589](https://github.com/adhearsion/adhearsion/issues/589)

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -324,7 +324,7 @@ module Adhearsion
 
     def reject(reason = :busy, headers = nil)
       write_and_await_response Adhearsion::Rayo::Command::Reject.new(:reason => reason, :headers => headers)
-      Adhearsion::Events.trigger_immediately :call_rejected, call: current_actor, reason: reason
+      Adhearsion::Events.trigger :call_rejected, call: current_actor, reason: reason
     rescue Adhearsion::ProtocolError => e
       abort e
     end

--- a/lib/adhearsion/initializer.rb
+++ b/lib/adhearsion/initializer.rb
@@ -86,7 +86,7 @@ module Adhearsion
     def catch_termination_signal
       self_read, self_write = IO.pipe
 
-      %w(INT TERM HUP ALRM ABRT).each do |sig|
+      %w(INT TERM HUP ALRM ABRT USR1).each do |sig|
         trap sig do
           self_write.puts sig
         end
@@ -117,6 +117,9 @@ module Adhearsion
       when 'ABRT'
         logger.info "Received ABRT signal. Forcing stop."
         Adhearsion::Process.force_stop
+      when 'USR1'
+        logger.info "Received USR1 signal. Printing Celluloid stack dump."
+        Celluloid.stack_dump(STDOUT)
       end
     end
 

--- a/lib/adhearsion/outbound_call.rb
+++ b/lib/adhearsion/outbound_call.rb
@@ -99,7 +99,7 @@ module Adhearsion
           Adhearsion.active_calls << current_actor
           Adhearsion.active_calls.delete(@id)
         end
-        Adhearsion::Events.trigger_immediately :call_dialed, current_actor
+        Adhearsion::Events.trigger :call_dialed, current_actor
       end
     rescue
       clear_from_active_calls

--- a/lib/adhearsion/router/route.rb
+++ b/lib/adhearsion/router/route.rb
@@ -26,7 +26,7 @@ module Adhearsion
       end
 
       def dispatch(call, callback = nil)
-        Adhearsion::Events.trigger_immediately :call_routed, call: call, route: self
+        Adhearsion::Events.trigger :call_routed, call: call, route: self
 
         call_id = call.id # Grab this to use later incase the actor is dead
 

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -992,7 +992,7 @@ module Adhearsion
 
         it "should immediately fire the :call_rejected event giving the call and the reason" do
           expect_message_waiting_for_response kind_of(Adhearsion::Rayo::Command::Reject)
-          expect(Adhearsion::Events).to receive(:trigger_immediately).once.with(:call_rejected, :call => subject, :reason => :decline)
+          expect(Adhearsion::Events).to receive(:trigger).once.with(:call_rejected, :call => subject, :reason => :decline)
           subject.reject :decline
         end
 

--- a/spec/adhearsion/outbound_call_spec.rb
+++ b/spec/adhearsion/outbound_call_spec.rb
@@ -280,7 +280,7 @@ module Adhearsion
         end
 
         it "should immediately fire the :call_dialed event giving the call" do
-          expect(Adhearsion::Events).to receive(:trigger_immediately).once.with(:call_dialed, subject)
+          expect(Adhearsion::Events).to receive(:trigger).once.with(:call_dialed, subject)
           subject.dial to, :from => from
         end
 

--- a/spec/adhearsion/router/route_spec.rb
+++ b/spec/adhearsion/router/route_spec.rb
@@ -138,7 +138,7 @@ module Adhearsion
           let(:route)       { Route.new 'foobar', controller }
 
           it "should immediately fire the :call_routed event giving the call and route" do
-            expect(Adhearsion::Events).to receive(:trigger_immediately).once.with(:call_routed, call: call, route: route)
+            expect(Adhearsion::Events).to receive(:trigger).once.with(:call_routed, call: call, route: route)
             expect(call).to receive(:hangup).once
             route.dispatch call, lambda { latch.countdown! }
             expect(latch.wait(2)).to be true


### PR DESCRIPTION
See https://github.com/celluloid/celluloid/issues/193

An app was easily getting into this sort of situation: https://gist.github.com/benlangfeld/243519d18981fc91e88d
