### PR TITLE
FIX: prevent actor crash on AMI action when asterisk unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Bugfix: Avoid celluloid actor crash when asterisk becomes unavailable
   * Bugfix: Handle more AMI error responses which mean the channel is not found
   * Bugfix: Reporting statistics should not deadlock call processing
   * Bugfix: Sending the `USR2` signal to an Adhearsion application now prints thread stack traces to STDERR.

--- a/lib/adhearsion/translator/asterisk/component/asterisk/ami_action.rb
+++ b/lib/adhearsion/translator/asterisk/component/asterisk/ami_action.rb
@@ -20,6 +20,8 @@ module Adhearsion
               send_complete_event success_reason(response, final_event)
             rescue RubyAMI::Error => e
               send_complete_event error_reason(e)
+            rescue Celluloid::DeadActorError
+              send_complete_event error_reason(RubyAMI::Error.new(action_headers))
             end
 
             private


### PR DESCRIPTION
When a call starts while asterisk is running and before the call is answered or terminated asterisk becomes unavailable, further ami actions related to that call will result in `Celluloid: Actor crashed!` error messages. This is caused because `...Asterisk::AMIAction#send_actions()` raises `Celluloid::DeadActorError`, that crashes the translator. Even if after a while asterisk becomes available, there isn't any translator to process AMI actions and events.
To fix this issue `Celluloid::DeadActorError` have to be caught within `...Asterisk::AMIAction#execute()`.

How to reproduce?
1. Start a call and let it ring
2. Kill asterisk process
3. Try to hangup the call or wait until the call goes in timeout

After asterisk becomes unavailable, `Adhearsion::Rayo::Initializer` will try to reconnect to asterisk, but in this state any attempt to execute an AMI action will crash the translator.
