### PR TITLE
Generate a script for i18n prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
   * Bugfix: Handle more AMI error responses which mean the channel is not found
   * Bugfix: Reporting statistics should not deadlock call processing
   * Bugfix: Sending the `USR2` signal to an Adhearsion application now prints thread stack traces to STDERR.
+  * Bugfix: Checking i18n prompts now handles nested keys
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)
+  * Feature: Add rake task to generate Markdown formatted prompt list for recording
 
 # [3.0.0.rc1](https://github.com/adhearsion/adhearsion/compare/v3.0.0.beta2...v3.0.0.rc1) - [2016-01-07](https://rubygems.org/gems/adhearsion/versions/3.0.0.rc1)
   * Bugfix: Concurrent access to call collection should not be permitted. See [#589](https://github.com/adhearsion/adhearsion/issues/589)

--- a/lib/adhearsion/tasks/i18n.rb
+++ b/lib/adhearsion/tasks/i18n.rb
@@ -18,7 +18,7 @@ namespace :i18n do
       locale = prompts.keys.first
       prompts = prompts[locale]
 
-      prompts.each_pair do |key, mapping|
+      each_prompt(prompts) do |key, mapping|
         logger.trace "Checking i18n key #{key}"
         # Not all prompts will have audio files
         next unless mapping['audio']
@@ -44,6 +44,69 @@ namespace :i18n do
       else
         logger.info "All configured prompt files successfully validated."
       end
+    end
+  end
+
+  desc "Generate recording script (Markdown format)"
+  task :generate_script do
+    @output_dir = File.join Adhearsion.root, 'doc'
+    File.mkdir @output_dir unless File.exist? @output_dir
+
+    seen_locales = Set.new
+    locale_files = Dir.glob(I18n.load_path)
+    locale_files.each do |locale_file|
+      # We only support YAML for now
+      next unless locale_file =~ /\.ya?ml$/
+
+      prompts = YAML.load File.read(locale_file)
+
+      seen_locales << locale = prompts.keys.first
+      prompts = prompts[locale]
+
+      File.open script_name(locale), 'w+' do |fh|
+        each_prompt(prompts) do |key, mapping|
+          logger.trace "Checking i18n key #{key}"
+
+          # Ignore any prompt that doesn't have a text translation
+          next unless mapping['text']
+          audiofile = mapping['audio'] ? mapping['audio'] : "#{key}.wav"
+
+          fh.puts "* `#{audiofile}`: \"#{mapping['text']}\""
+          fh.puts
+        end
+      end
+
+    end
+
+    seen_locales.each do |locale|
+      if File.zero? script_name(locale)
+        logger.warn "No prompts found, script not created."
+        File.unlink script_name(locale)
+      else
+        logger.info "Audio recording script written to #{script_name(locale)}"
+      end
+    end
+  end
+
+  def script_name(locale)
+    File.join @output_dir, "prompts_#{locale}.md"
+  end
+
+  def children(node)
+    node.is_a?(Hash) && node.keys - ['text', 'audio'] || []
+  end
+
+  def prompt?(node)
+    node.is_a?(Hash) && (node.key?('text') || node.key?('audio'))
+  end
+
+  def each_prompt(collection, prefix = '', &block)
+    collection.each do |key, data|
+      next if ['text', 'audio'].include? key
+      current_prefix = prefix.empty? ? prefix : "#{prefix}."
+      current_prefix += key.to_s
+      each_prompt(data, current_prefix, &block) unless children(data).empty?
+      yield current_prefix, data if prompt? data
     end
   end
 end


### PR DESCRIPTION
Matching PR for adhearsion/adhearsion-i18n#8

This rake task will generate a script in Markdown format suitable for sharing with the person who will record the prompts.

Todo:
- [x] Handle nested values (eg. `ivr_section.main_menu`)
- [x] Let the audio filename attribute override the i18n key, if provided
