### PR TITLE
Extracting call controller output translator to `Adhearsion::I18n`

### DIFF
--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -144,4 +144,5 @@ end
   protocol_error
   router
   statistics
+  i18n
 ).each { |f| require "adhearsion/#{f}" }

--- a/lib/adhearsion/call_controller/output.rb
+++ b/lib/adhearsion/call_controller/output.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'uri'
-require 'i18n'
 
 %w(
   abstract_player
@@ -274,35 +273,11 @@ module Adhearsion
       end
 
       def t(key, options = {})
-        this_locale = options[:locale] || locale
-        options = {default: '', locale: locale}.merge(options)
-        prompt = ::I18n.t "#{key}.audio", options
-        text   = ::I18n.t "#{key}.text", options
-
-        if prompt.empty? && text.empty?
-          # Look for a translation key that doesn't follow the Adhearsion-I18n structure
-          text = ::I18n.t key, options
-        end
-
-        unless prompt.empty?
-          prompt = "file://#{Adhearsion.root + "/" unless Adhearsion.config.core.i18n.audio_path.start_with?("/")}#{Adhearsion.config.core.i18n.audio_path}/#{this_locale}/#{prompt}"
-        end
-
-        RubySpeech::SSML.draw language: this_locale do
-          if prompt.empty?
-            string text
-          else
-            if Adhearsion.config.core.i18n.fallback
-              audio(src: prompt) { string text }
-            else
-              audio(src: prompt)
-            end
-          end
-        end
+        Adhearsion::I18n.t key, { locale: locale }.merge(options || {})
       end
 
       def locale
-        call[:locale] || I18n.default_locale
+        call[:locale] || Adhearsion::I18n.locale
       end
 
       def locale=(l)

--- a/lib/adhearsion/i18n.rb
+++ b/lib/adhearsion/i18n.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+require 'i18n'
+
+module Adhearsion
+  module I18n
+    def self.t(key, options = {})
+      this_locale = options[:locale] || locale
+      options = {default: '', locale: locale}.merge(options)
+      prompt = ::I18n.t "#{key}.audio", options
+      text   = ::I18n.t "#{key}.text", options
+
+      if prompt.empty? && text.empty?
+        # Look for a translation key that doesn't follow the Adhearsion-I18n structure
+        text = ::I18n.t key, options
+      end
+
+      unless prompt.empty?
+        prompt = "file://#{Adhearsion.root + "/" unless Adhearsion.config.core.i18n.audio_path.start_with?("/")}#{Adhearsion.config.core.i18n.audio_path}/#{this_locale}/#{prompt}"
+      end
+
+      RubySpeech::SSML.draw language: this_locale do
+        if prompt.empty?
+          string text
+        else
+          if Adhearsion.config.core.i18n.fallback
+            audio(src: prompt) { string text }
+          else
+            audio(src: prompt)
+          end
+        end
+      end
+    end
+
+    def self.locale
+      ::I18n.locale
+    end
+  end # I18n
+end # Adhearsion

--- a/lib/adhearsion/initializer.rb
+++ b/lib/adhearsion/initializer.rb
@@ -79,7 +79,7 @@ module Adhearsion
     def setup_i18n_load_path
       Adhearsion.config.core.i18n.locale_path.each do |dir|
         logger.debug "Adding #{dir} to the I18n load path"
-        I18n.load_path += Dir["#{dir}/**/*.yml"]
+        ::I18n.load_path += Dir["#{dir}/**/*.yml"]
       end
     end
 

--- a/spec/adhearsion/call_controller/output_spec.rb
+++ b/spec/adhearsion/call_controller/output_spec.rb
@@ -943,7 +943,7 @@ module Adhearsion
 
       describe "i18n" do
         before do
-          I18n.default_locale = :en
+          ::I18n.locale = :en
         end
 
         describe 'getting and setting the locale' do
@@ -971,78 +971,6 @@ module Adhearsion
             expect(ssml['xml:lang']).to match(/^it/)
             controller2 = Class.new(Adhearsion::CallController).new call
             expect(controller2.locale).to eql('it')
-          end
-
-          it 'should generate proper SSML with both audio and text fallback translations' do
-            ssml = controller.t :have_many_cats
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              audio src: "file://#{Adhearsion.root}/app/assets/audio/en/have_many_cats.wav" do
-                string 'I have quite a few cats'
-              end
-            end)
-          end
-
-          it 'should generate proper SSML with only audio (no fallback text) translations' do
-            ssml = controller.t :my_shirt_is_white
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              audio src: "file://#{Adhearsion.root}/app/assets/audio/en/my_shirt_is_white.wav" do
-                string ''
-              end
-            end)
-          end
-
-          it 'should generate proper SSML with only text (no audio) translations' do
-            ssml = controller.t :many_people_out_today
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              string 'There are many people out today'
-            end)
-          end
-
-          it 'should generate a path to the audio prompt based on the requested locale' do
-            ssml = controller.t :my_shirt_is_white, locale: 'it'
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'it') do
-              audio src: "file://#{Adhearsion.root}/app/assets/audio/it/la_mia_camicia_e_bianca.wav" do
-                string ''
-              end
-            end)
-          end
-
-          it 'should fall back to a text translation if the locale structure does not break out audio vs. tts' do
-            ssml = controller.t :seventeen, locale: 'it'
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'it') do
-              string 'diciassette'
-            end)
-          end
-        end
-
-        describe 'with fallback disabled, requesting a translation' do
-          before do
-            Adhearsion.config.core.i18n.fallback = false
-          end
-
-          after do
-            Adhearsion.config.core.i18n.fallback = true
-          end
-
-          it 'should generate proper SSML with only audio (no text) translations' do
-            ssml = controller.t :my_shirt_is_white
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              audio src: "file://#{Adhearsion.root}/app/assets/audio/en/my_shirt_is_white.wav"
-            end)
-          end
-
-          it 'should generate proper SSML with only text (no audio) translations' do
-            ssml = controller.t :many_people_out_today
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              string 'There are many people out today'
-            end)
-          end
-
-          it 'should generate proper SSML with only audio translations when both are supplied' do
-            ssml = controller.t :have_many_cats
-            expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
-              audio src: "file://#{Adhearsion.root}/app/assets/audio/en/have_many_cats.wav"
-            end)
           end
         end
       end

--- a/spec/adhearsion/i18n_spec.rb
+++ b/spec/adhearsion/i18n_spec.rb
@@ -1,0 +1,110 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Adhearsion
+  describe I18n do
+    describe '#locale' do
+      around do |example|
+        enforce_available_locales = ::I18n.enforce_available_locales
+        ::I18n.enforce_available_locales = false
+        example.run
+        ::I18n.enforce_available_locales = enforce_available_locales
+      end
+
+      after do
+        ::I18n.locale = ::I18n.default_locale
+      end
+
+      it 'returns the set I18n locale' do
+        expect(described_class.locale).to eq(::I18n.default_locale)
+        ::I18n.locale = :it
+        expect(described_class.locale).to eq(:it)
+      end
+    end
+
+    describe '#t' do
+      it 'should use a default locale' do
+        ssml = described_class.t :have_many_cats
+        expect(ssml['xml:lang']).to match(/^en/)
+      end
+
+      it 'should allow overriding the locale per-request' do
+        ssml = described_class.t :have_many_cats, locale: 'it'
+        expect(ssml['xml:lang']).to match(/^it/)
+      end
+
+      it 'should generate proper SSML with both audio and text fallback translations' do
+        ssml = described_class.t :have_many_cats
+        expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+          audio src: "file://#{Adhearsion.root}/app/assets/audio/en/have_many_cats.wav" do
+            string 'I have quite a few cats'
+          end
+        end)
+      end
+
+      it 'should generate proper SSML with only audio (no fallback text) translations' do
+        ssml = described_class.t :my_shirt_is_white
+        expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+          audio src: "file://#{Adhearsion.root}/app/assets/audio/en/my_shirt_is_white.wav" do
+            string ''
+          end
+        end)
+      end
+
+      it 'should generate proper SSML with only text (no audio) translations' do
+        ssml = described_class.t :many_people_out_today
+        expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+          string 'There are many people out today'
+        end)
+      end
+
+      it 'should generate a path to the audio prompt based on the requested locale' do
+        ssml = described_class.t :my_shirt_is_white, locale: 'it'
+        expect(ssml).to eql(RubySpeech::SSML.draw(language: 'it') do
+          audio src: "file://#{Adhearsion.root}/app/assets/audio/it/la_mia_camicia_e_bianca.wav" do
+            string ''
+          end
+        end)
+      end
+
+      it 'should fall back to a text translation if the locale structure does not break out audio vs. tts' do
+        ssml = described_class.t :seventeen, locale: 'it'
+        expect(ssml).to eql(RubySpeech::SSML.draw(language: 'it') do
+          string 'diciassette'
+        end)
+      end
+
+      context 'with fallback disabled, requesting a translation' do
+        before do
+          Adhearsion.config.core.i18n.fallback = false
+        end
+
+        after do
+          Adhearsion.config.core.i18n.fallback = true
+        end
+
+        it 'should generate proper SSML with only audio (no text) translations' do
+          ssml = described_class.t :my_shirt_is_white
+          expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+            audio src: "file://#{Adhearsion.root}/app/assets/audio/en/my_shirt_is_white.wav"
+          end)
+        end
+
+        it 'should generate proper SSML with only text (no audio) translations' do
+          ssml = described_class.t :many_people_out_today
+          expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+            string 'There are many people out today'
+          end)
+        end
+
+        it 'should generate proper SSML with only audio translations when both are supplied' do
+          ssml = described_class.t :have_many_cats
+          expect(ssml).to eql(RubySpeech::SSML.draw(language: 'en') do
+            audio src: "file://#{Adhearsion.root}/app/assets/audio/en/have_many_cats.wav"
+          end)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Counterpart PR for adhearsion/adhearsion-i18n#11.

This allows the translator method to be used from outside Adhearsion
call controllers (as AdhearsionI18n.t).
