### PR TITLE
Set Sinatra’s root to Adhearsion’s root

### DIFF
--- a/lib/adhearsion/generators/app/templates/config.ru
+++ b/lib/adhearsion/generators/app/templates/config.ru
@@ -1,5 +1,7 @@
 require 'sinatra'
 
+set :root, Adhearsion.root
+
 get '/' do
   'Hello world!'
 end


### PR DESCRIPTION
This makes Sinatra properly serve “#{Adhearsion.root}/public” as the public files folder
