### PR TITLE
Hangup call controller on PB Cmd Complete with reason Hangup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [develop](https://github.com/adhearsion/adhearsion)
 
+# [2.6.3](https://github.com/adhearsion/adhearsion/compare/v2.6.2...v2.6.3) - [2016-12-19](https://rubygems.org/gems/adhearsion/versions/2.6.3)
+  * Feature: CallController execution does not continue after hangup during play, speak, record or ask  [#614](https://github.com/adhearsion/adhearsion/pull/#614).
+
 # [2.6.2](https://github.com/adhearsion/adhearsion/compare/v2.6.1...v2.6.2) - [2015-06-16](https://rubygems.org/gems/adhearsion/versions/2.6.2)
   * Bugfix: Properly load application bundle. This requires the spawning removed in [#534](https://github.com/adhearsion/adhearsion/pull/534).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 # [develop](https://github.com/adhearsion/adhearsion)
-
-# [2.6.3](https://github.com/adhearsion/adhearsion/compare/v2.6.2...v2.6.3) - [2016-12-19](https://rubygems.org/gems/adhearsion/versions/2.6.3)
   * Feature: CallController execution does not continue after hangup during play, speak, record or ask  [#614](https://github.com/adhearsion/adhearsion/pull/#614).
 
 # [2.6.2](https://github.com/adhearsion/adhearsion/compare/v2.6.1...v2.6.2) - [2015-06-16](https://rubygems.org/gems/adhearsion/versions/2.6.2)

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -245,6 +245,7 @@ module Adhearsion
 
       on_end do |event|
         logger.info "Call #{from} -> #{to} ended due to #{event.reason}#{" (code #{event.platform_code})" if event.platform_code}"
+        terminating!
         @end_time = event.timestamp.to_time
         @duration = @end_time - @start_time if @start_time
         clear_from_active_calls

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -212,7 +212,7 @@ module Adhearsion
 
       register_event_handler Punchblock::Event::Complete do |event|
         if event.reason.is_a? Punchblock::Event::Complete::Hangup
-          @call_terminating = true
+          terminating!
         end
       end
 
@@ -298,6 +298,10 @@ module Adhearsion
 
     def on_end(&block)
       register_event_handler Punchblock::Event::End, &block
+    end
+
+    def terminating!
+      @call_terminating = true
     end
 
     #

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -304,7 +304,7 @@ module Adhearsion
     # @return [Boolean] if the call is currently terminating/terminated
     #
     def terminating?
-      !alive? || !active? || @call_terminating
+      !active? || @call_terminating
     end
 
     #

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -212,7 +212,7 @@ module Adhearsion
 
       register_event_handler Punchblock::Event::Complete do |event|
         if event.reason.is_a? Punchblock::Event::Complete::Hangup
-          terminating!
+          terminating! unless terminating?
         end
       end
 
@@ -245,7 +245,7 @@ module Adhearsion
 
       on_end do |event|
         logger.info "Call #{from} -> #{to} ended due to #{event.reason}#{" (code #{event.platform_code})" if event.platform_code}"
-        terminating!
+        terminating! unless terminating?
         @end_time = event.timestamp.to_time
         @duration = @end_time - @start_time if @start_time
         clear_from_active_calls
@@ -302,6 +302,7 @@ module Adhearsion
     end
 
     def terminating!
+      logger.debug "Call is terminating"
       @call_terminating = true
     end
 

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -89,6 +89,7 @@ module Adhearsion
       @duration     = nil
       @auto_hangup  = true
       @after_hangup_lifetime = nil
+      @call_terminating = false
 
       self << offer if offer
     end
@@ -209,6 +210,12 @@ module Adhearsion
         merge_headers event.headers
       end
 
+      register_event_handler Punchblock::Event::Complete do |event|
+        if event.reason.is_a? Punchblock::Event::Complete::Hangup
+          @call_terminating = true
+        end
+      end
+
       on_joined do |event|
         if event.call_uri
           target = event.call_uri
@@ -291,6 +298,13 @@ module Adhearsion
 
     def on_end(&block)
       register_event_handler Punchblock::Event::End, &block
+    end
+
+    #
+    # @return [Boolean] if the call is currently terminating/terminated
+    #
+    def terminating?
+      !alive? || !active? || @call_terminating
     end
 
     #

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -223,7 +223,7 @@ module Adhearsion
       complete_event = component.complete_event
       raise Adhearsion::Error, [complete_event.reason.details, component.inspect].join(": ") if complete_event.reason.is_a? Punchblock::Event::Complete::Error
       if complete_event.reason.is_a? Punchblock::Event::Complete::Hangup
-        call.async.terminating!
+        call.terminating!
         hangup
       end
       component

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -223,8 +223,8 @@ module Adhearsion
       complete_event = component.complete_event
       raise Adhearsion::Error, [complete_event.reason.details, component.inspect].join(": ") if complete_event.reason.is_a? Punchblock::Event::Complete::Error
       if complete_event.reason.is_a? Punchblock::Event::Complete::Hangup
-        call.terminating!
-        hangup
+        call.terminating! unless call.terminating?
+        raise Call::Hangup
       end
       component
     end

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -73,21 +73,9 @@ module Adhearsion
     # @param block to execute on the call
     #
     def initialize(call, metadata = nil, &block)
-      @call_hangup_flag = false
-      if call.alive? && call.active?
-        call.register_event_handler Punchblock::Event::Complete do |event|
-          if event.reason.is_a? Punchblock::Event::Complete::Hangup
-            @call_hangup_flag = true
-          end
-        end
-      end
       @call, @metadata, @block = call, metadata || {}, block
       @block_context = eval "self", @block.binding if @block
       @active_components = []
-    end
-
-    def is_current_call_terminatig?
-      @call_hangup_flag || !call.active?
     end
 
     def method_missing(method_name, *args, &block)

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -73,9 +73,21 @@ module Adhearsion
     # @param block to execute on the call
     #
     def initialize(call, metadata = nil, &block)
+      @call_hangup_flag = false
+      if call.alive? && call.active?
+        call.register_event_handler Punchblock::Event::Complete do |event|
+          if event.reason.is_a? Punchblock::Event::Complete::Hangup
+            @call_hangup_flag = true
+          end
+        end
+      end
       @call, @metadata, @block = call, metadata || {}, block
       @block_context = eval "self", @block.binding if @block
       @active_components = []
+    end
+
+    def is_current_call_terminatig?
+      @call_hangup_flag || !call.active?
     end
 
     def method_missing(method_name, *args, &block)
@@ -222,6 +234,7 @@ module Adhearsion
 
       complete_event = component.complete_event
       raise Adhearsion::Error, [complete_event.reason.details, component.inspect].join(": ") if complete_event.reason.is_a? Punchblock::Event::Complete::Error
+      hangup if complete_event.reason.is_a? Punchblock::Event::Complete::Hangup
       component
     end
 

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -222,7 +222,10 @@ module Adhearsion
 
       complete_event = component.complete_event
       raise Adhearsion::Error, [complete_event.reason.details, component.inspect].join(": ") if complete_event.reason.is_a? Punchblock::Event::Complete::Error
-      hangup if complete_event.reason.is_a? Punchblock::Event::Complete::Hangup
+      if complete_event.reason.is_a? Punchblock::Event::Complete::Hangup
+        call.async.terminating!
+        hangup
+      end
       component
     end
 

--- a/lib/adhearsion/version.rb
+++ b/lib/adhearsion/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Adhearsion
-  VERSION = '2.6.3'
+  VERSION = '2.6.2'
 end

--- a/lib/adhearsion/version.rb
+++ b/lib/adhearsion/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Adhearsion
-  VERSION = '2.6.2'
+  VERSION = '2.6.3'
 end

--- a/spec/adhearsion/call_controller_spec.rb
+++ b/spec/adhearsion/call_controller_spec.rb
@@ -571,6 +571,22 @@ module Adhearsion
         end
       end
 
+      describe "with complete event with reason hangup" do
+
+        let(:response) do
+          Punchblock::Event::Complete.new :reason => complete_reason
+        end
+
+        let(:complete_reason) do
+          Punchblock::Event::Complete::Hangup.new
+        end
+
+        it "raises the hangup" do
+          expect { subject.execute_component_and_await_completion component }.to raise_error(Call::Hangup)
+        end
+
+      end
+
       it "blocks until the component receives a complete event" do
         slow_component = Punchblock::Component::Output.new
         slow_component.request!

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -557,6 +557,11 @@ module Adhearsion
           Punchblock::Event::End.new :reason => :hangup, :platform_code => 'arbitrary_code'
         end
 
+        it "should mark the call as terminating" do
+          subject << end_event
+          expect(subject.terminating?).to be true
+        end
+
         it "should mark the call as ended" do
           subject << end_event
           expect(subject).not_to be_active

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -552,6 +552,17 @@ module Adhearsion
     end
 
     describe "#<<" do
+      describe "with a Punchblock Complete Event and Reason Hangup" do
+        let :complete_event do
+          Punchblock::Event::Complete.new :reason => Punchblock::Event::Complete::Hangup.new
+        end
+
+        it "should mark the call as terminating" do
+          subject << complete_event
+          expect(subject.terminating?).to be true
+        end
+      end
+
       describe "with a Punchblock End" do
         let :end_event do
           Punchblock::Event::End.new :reason => :hangup, :platform_code => 'arbitrary_code'


### PR DESCRIPTION
If I execute a command (E.G. play a file, ask a digit, etc) and the caller hangup during the command, the code written after the command in the controller should not be executed.