### PR TITLE
[FEATURE] yielding dial object during Dial#dial

### DIFF
--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -48,6 +48,8 @@ module Adhearsion
       #
       # @option options [Array, #call] :ringback A collection of audio (see #play for acceptable values) to render as a replacement for ringback. If a callback is passed, it will be used to start ringback, and must return something that responds to #stop! to stop it.
       #
+      # @yield [Adhearsion::CallController::Dial::Dial] Provides the newly initialized Dial object to the given block, particularly useful in order to obtain a reference to it for later use.
+      #
       # @example Make a call to the PSTN using my SIP provider for VoIP termination
       #   dial "SIP/19095551001@my.sip.voip.terminator.us"
       #
@@ -61,6 +63,7 @@ module Adhearsion
       #
       def dial(to, options = {})
         dial = Dial.new to, options, call
+        yield dial if block_given?
         dial.run(self)
         dial.await_completion
         dial.terminate_ringback

--- a/spec/adhearsion/call_controller/dial_spec.rb
+++ b/spec/adhearsion/call_controller/dial_spec.rb
@@ -1485,6 +1485,17 @@ module Adhearsion
             end
           end
         end
+
+        context 'when given a block with one argument' do
+          it "yields a block on the dial obj" do
+            expect(OutboundCall).to receive(:new).and_return other_mock_call
+            expect(other_mock_call).to receive(:dial).with(to, options).once
+            Thread.new do
+              expect {|b| subject.dial(to, options, &b)}.to yield_with_args Dial
+            end
+            sleep 0.1
+          end
+        end
       end
 
       describe Dial::Dial do


### PR DESCRIPTION
attn @sfgeorge, @lpradovera

Yielding the newly initialized dial object during `Dial#dial`, primarily so that we can access the dial object later for subsequent calls to `split` and `rejoin`.