### PR TITLE
[BUGFIX] fixing duration as seconds rather than days when using activesupport versions 3.x

### DIFF
--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -256,7 +256,7 @@ module Adhearsion
       on_end do |event|
         logger.info "Call #{from} -> #{to} ended due to #{event.reason}#{" (code #{event.platform_code})" if event.platform_code}"
         @end_time = event.timestamp.to_time
-        @duration = @end_time - @start_time if @start_time
+        @duration = @end_time.to_i - @start_time.to_i if @start_time
         clear_from_active_calls
         @end_reason = event.reason
         @end_code = event.platform_code
@@ -271,7 +271,7 @@ module Adhearsion
       if @duration
         @duration
       elsif @start_time
-        Time.now - @start_time
+        Time.now.to_i - @start_time.to_i
       else
         0.0
       end

--- a/lib/adhearsion/call_controller/dial.rb
+++ b/lib/adhearsion/call_controller/dial.rb
@@ -477,7 +477,7 @@ module Adhearsion
         # The duration for which the calls were joined. Does not include time spent in confirmation controllers or after being separated.
         def duration
           if start_time && end_time
-            end_time - start_time
+            end_time.to_i - start_time.to_i
           else
             0.0
           end


### PR DESCRIPTION
attn @sfgeorge, @lpradovera

Here's what gets several `duration` specs passing with ActiveSupport 3.X, by avoiding the unexpected 'do-nothingness' of DateTime#to_time when the object has an offset.  In short:
* `DateTime` subtraction gives units of days
* `Time` subtraction gives units of seconds
* `DateTime#to_time` returns `self` when the object has a non-zero offset, in our 3.2.22.1 version of activesupport, so we end up with duration calculated in `days` rather than the expected `seconds`.  e.g. failure:
```1) Adhearsion::CallController::Dial#dial without a block when the call is answered and joined records the duration of the join
   Failure/Error: expect(joined_status.duration).to eq(37.0)

     expected: 37.0
          got: (37/86400)

     (compared using ==)
   # ./spec/adhearsion/call_controller/dial_spec.rb:318:in `CallController'
```

Proposed solution is to universally convert to seconds first via `.to_i`, rather than rely on `.to_time`.