### PR TITLE
Short call leakage mitigation (v3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.3.0
-  - jruby-9.0.4.0
+  - 2.3.6
+  - 2.4.3
+  - jruby-9.1.16.0
   - ruby-head
 jdk:
-  - openjdk7 # for jruby
-before_script: export JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
+  - openjdk8 # for jruby
 matrix:
   allow_failures:
     - rvm: ruby-head
-env: ARUBA_TIMEOUT=120 AHN_ENV=development
+env: ARUBA_TIMEOUT=120 AHN_ENV=development JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
 sudo: false
 notifications:
   slack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)
   * Feature: Add rake task to generate Markdown formatted prompt list for recording
+  * Feature: Increases concurrent call routing performance by delegating call routing to Call actors
 
 # [3.0.0.rc1](https://github.com/adhearsion/adhearsion/compare/v3.0.0.beta2...v3.0.0.rc1) - [2016-01-07](https://rubygems.org/gems/adhearsion/versions/3.0.0.rc1)
   * Bugfix: Concurrent access to call collection should not be permitted. See [#589](https://github.com/adhearsion/adhearsion/issues/589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Bugfix: Sending the `USR2` signal to an Adhearsion application now prints thread stack traces to STDERR.
   * Bugfix: Checking i18n prompts now handles nested keys
   * Bugfix: Shuts down a call which couldn't be routed with a fake end event. This avoids leaking call actors in cases where the call ended before it was dispatched and we missed the real End event.
+  * Bugfix: Removes proactive checks on call availability before dispatching events because these are inaccurate; now optimistically dispatches.
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Bugfix: Reporting statistics should not deadlock call processing
   * Bugfix: Sending the `USR2` signal to an Adhearsion application now prints thread stack traces to STDERR.
   * Bugfix: Checking i18n prompts now handles nested keys
+  * Bugfix: Shuts down a call which couldn't be routed with a fake end event. This avoids leaking call actors in cases where the call ended before it was dispatched and we missed the real End event.
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -520,6 +520,9 @@ module Adhearsion
       else
         reject :error
       end
+    rescue Call::Hangup, Call::ExpiredError
+      logger.warn "Call routing could not be completed because call was unavailable."
+      self << Adhearsion::Event::End.new(reason: :error)
     end
 
     ##

--- a/lib/adhearsion/call.rb
+++ b/lib/adhearsion/call.rb
@@ -509,6 +509,19 @@ module Adhearsion
       client.execute_command command
     end
 
+    def route
+      case Adhearsion::Process.state_name
+      when :booting, :rejecting
+        logger.info "Declining call because the process is not yet running."
+        reject :decline
+      when :running, :stopping
+        logger.info "Routing call"
+        Adhearsion.router.handle current_actor
+      else
+        reject :error
+      end
+    end
+
     ##
     # Sends a message to the caller
     #

--- a/lib/adhearsion/rayo/initializer.rb
+++ b/lib/adhearsion/rayo/initializer.rb
@@ -130,15 +130,7 @@ module Adhearsion
           catching_standard_errors do
             call = Call.new(offer)
             Adhearsion.active_calls << call
-            case Adhearsion::Process.state_name
-            when :booting, :rejecting
-              logger.info "Declining call because the process is not yet running."
-              call.reject :decline
-            when :running, :stopping
-              Adhearsion.router.handle call
-            else
-              call.reject :error
-            end
+            call.async.route
           end
         end
 

--- a/lib/adhearsion/rayo/initializer.rb
+++ b/lib/adhearsion/rayo/initializer.rb
@@ -135,8 +135,7 @@ module Adhearsion
         end
 
         def dispatch_call_event(event)
-          call = Adhearsion.active_calls[event.target_call_id]
-          if call && call.alive?
+          if call = Adhearsion.active_calls[event.target_call_id]
             call.async.deliver_message event
           else
             logger.warn "Event received for inactive call #{event.target_call_id}: #{event.inspect}"

--- a/lib/adhearsion/router/route.rb
+++ b/lib/adhearsion/router/route.rb
@@ -54,8 +54,6 @@ module Adhearsion
           end
           callback.call if callback
         }
-      rescue Call::Hangup, Call::ExpiredError
-        logger.info "Call routing could not be completed because call was unavailable."
       end
 
       def evented?

--- a/spec/adhearsion/call_spec.rb
+++ b/spec/adhearsion/call_spec.rb
@@ -39,6 +39,16 @@ module Adhearsion
       Adhearsion.active_calls.clear
     end
 
+    def expect_message_waiting_for_response(message = nil, fail = false, &block)
+      expectation = expect(subject.wrapped_object).to receive(:write_and_await_response, &block).once
+      expectation = expectation.with message if message
+      if fail
+        expectation.and_raise fail
+      else
+        expectation.and_return message
+      end
+    end
+
     it "should do recursion detection on inspect" do
       subject[:foo] = subject
       Timeout.timeout(0.2) do
@@ -869,6 +879,51 @@ module Adhearsion
       end
     end
 
+    describe "routing" do
+      before do
+        expect(Adhearsion::Process).to receive(:state_name).once.and_return process_state
+      end
+
+      after { subject.route }
+
+      context "when the Adhearsion::Process is :booting" do
+        let(:process_state) { :booting }
+
+        it 'should reject a call with cause :declined' do
+          expect_message_waiting_for_response Adhearsion::Rayo::Command::Reject.new(reason: :decline)
+        end
+      end
+
+      [ :running, :stopping ].each do |state|
+        context "when when Adhearsion::Process is in :#{state}" do
+          let(:process_state) { state }
+
+          it "should dispatch via the router" do
+            Adhearsion.router do
+              route 'foobar', Class.new
+            end
+            expect(Adhearsion.router).to receive(:handle).once.with subject
+          end
+        end
+      end
+
+      context "when when Adhearsion::Process is in :rejecting" do
+        let(:process_state) { :rejecting }
+
+        it 'should reject a call with cause :declined' do
+          expect_message_waiting_for_response Adhearsion::Rayo::Command::Reject.new(reason: :decline)
+        end
+      end
+
+      context "when when Adhearsion::Process is not :running, :stopping or :rejecting" do
+        let(:process_state) { :foobar }
+
+        it 'should reject a call with cause :error' do
+          expect_message_waiting_for_response Adhearsion::Rayo::Command::Reject.new(reason: :error)
+        end
+      end
+    end
+
     describe "#send_message" do
       it "should send a message through the Rayo connection using the call ID and domain" do
         expect(subject.wrapped_object).to receive(:client).once.and_return mock_client
@@ -884,16 +939,6 @@ module Adhearsion
     end
 
     describe "basic control commands" do
-      def expect_message_waiting_for_response(message = nil, fail = false, &block)
-        expectation = expect(subject.wrapped_object).to receive(:write_and_await_response, &block).once
-        expectation = expectation.with message if message
-        if fail
-          expectation.and_raise fail
-        else
-          expectation.and_return message
-        end
-      end
-
       describe '#accept' do
         describe "with no headers" do
           it 'should send an Accept message' do

--- a/spec/adhearsion/rayo/initializer_spec.rb
+++ b/spec/adhearsion/rayo/initializer_spec.rb
@@ -266,18 +266,6 @@ describe Adhearsion::Rayo::Initializer do
         described_class.dispatch_call_event mock_event
       end
     end
-
-    describe "when the registry contains a dead call" do
-      before do
-        mock_call.terminate
-        Adhearsion.active_calls[mock_call.id] = mock_call
-      end
-
-      it "should log a warning" do
-        expect(Adhearsion::Logging.get_logger(described_class)).to receive(:warn).once.with("Event received for inactive call #{call_id}: #{mock_event.inspect}")
-        described_class.dispatch_call_event mock_event
-      end
-    end
   end
 
   context "rayo configuration" do

--- a/spec/adhearsion/router/route_spec.rb
+++ b/spec/adhearsion/router/route_spec.rb
@@ -164,16 +164,8 @@ module Adhearsion
           context "when the call has already ended before routing can begin" do
             before { Celluloid::Actor.kill call }
 
-            it "should fall through cleanly" do
-              expect { route.dispatch call }.not_to raise_error
-            end
-          end
-
-          context "when the call has already ended before routing can begin" do
-            before { Celluloid::Actor.kill call }
-
-            it "should fall through cleanly" do
-              expect { route.dispatch call }.not_to raise_error
+            it "should raise a hangup exception" do
+              expect { route.dispatch call }.to raise_error(Call::ExpiredError)
             end
           end
 


### PR DESCRIPTION
This is a rebase of #610 against master for v3. I had to leave out 0279499dd2d1bd5116b21443874c7e1c263e2135 because it caused deadlocks when combined with de171a9669948a8bb8982c962e7c1a331fb4514b. All the tests are passing and I have confirmed that it has fixed the issue I was seeing. I suspect Travis will fail because Blather needs a new release with EventMachine pinned back but we'll see.