### PR TITLE
Don't trigger the exception event handler twice per exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Bugfix: Checking i18n prompts now handles nested keys
   * Bugfix: Shuts down a call which couldn't be routed with a fake end event. This avoids leaking call actors in cases where the call ended before it was dispatched and we missed the real End event.
   * Bugfix: Removes proactive checks on call availability before dispatching events because these are inaccurate; now optimistically dispatches.
+  * Bugfix: Don't trigger the exception event handler twice per exception
   * Change: `Adhearsion::Call#start_time` now consistently tracks the call start time for both incoming and outgoing calls
   * Feature: Add `Adhearsion::Call#answer_time` to track the time at which the call was answered
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)

--- a/lib/adhearsion/call_controller.rb
+++ b/lib/adhearsion/call_controller.rb
@@ -127,7 +127,6 @@ module Adhearsion
       run
     rescue Call::Hangup, Call::ExpiredError
     rescue SyntaxError, StandardError => e
-      Events.trigger :exception, [e, logger]
       on_error e
       raise
     ensure

--- a/spec/adhearsion/call_controller_spec.rb
+++ b/spec/adhearsion/call_controller_spec.rb
@@ -79,18 +79,15 @@ module Adhearsion
         end
       end
 
-      it "catches standard errors, triggering an exception event" do
-        expect(subject).to receive(:run).once.ordered.and_raise(StandardError)
-        latch = CountDownLatch.new 1
-        ex = lo = nil
-        Events.exception do |e, l|
-          ex, lo = e, l
-          latch.countdown!
+      it "catches standard errors, triggering on_error callbacks" do
+        ex = nil
+        klass = Class.new(CallController) do
+          on_error { ex = @error }
         end
+        subject = new_controller(klass)
+        expect(subject).to receive(:run).once.ordered.and_raise(StandardError)
         expect { subject.exec }.to raise_error
-        expect(latch.wait(1)).to be true
         expect(ex).to be_a StandardError
-        expect(lo).to be subject.logger
       end
 
       context "when a block is specified" do


### PR DESCRIPTION
This resulted in exceptions being logged twice. We don't need to call `catching_standard_errors` in `CallController#bg_exec` because the handler is already triggered in `CallController#execute!`. We do still have to rescue the exceptions though, otherwise they leak out into Celluloid and actually get logged three times!

Fixes #618.