### PR TITLE
Bump Reel version to 0.6.x, fixing client disconnection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Feature: Send `Adhearsion::Event::Answered` events when inbound calls are answered (formerly was only sent when outbound calls were answered)
   * Feature: Add rake task to generate Markdown formatted prompt list for recording
   * Feature: Increases concurrent call routing performance by delegating call routing to Call actors
+  * Update: Bump Reel version to 0.6.x, fixing client disconnection bug
 
 # [3.0.0.rc1](https://github.com/adhearsion/adhearsion/compare/v3.0.0.beta2...v3.0.0.rc1) - [2016-01-07](https://rubygems.org/gems/adhearsion/versions/3.0.0.rc1)
   * Bugfix: Concurrent access to call collection should not be permitted. See [#589](https://github.com/adhearsion/adhearsion/issues/589)

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -31,13 +31,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ffi', ["~> 1.0"]
   s.add_runtime_dependency 'future-resource', ["~> 1.0"]
   s.add_runtime_dependency 'has-guarded-handlers', ["~> 1.6", ">= 1.6.3"]
-  s.add_runtime_dependency 'http', ["~> 0.9.8"] # Pin back so Reel doesn't break
   s.add_runtime_dependency 'i18n', ["~> 0.6"]
   s.add_runtime_dependency 'logging', ["~> 2.0"]
   s.add_runtime_dependency 'nokogiri', ["~> 1.5", ">= 1.5.6"]
   s.add_runtime_dependency 'pry'
   s.add_runtime_dependency 'rake'
-  s.add_runtime_dependency 'reel', ["~> 0.5.0"]
+  s.add_runtime_dependency 'reel', ["~> 0.6.0"]
   s.add_runtime_dependency 'reel-rack', ["~> 0.2.0"]
   s.add_runtime_dependency 'ruby_ami', ["~> 2.2"]
   s.add_runtime_dependency 'ruby_jid', ["~> 1.0"]


### PR DESCRIPTION
It works (not that the Adhearsion code does much with it) and fixes a nasty issue that's been keeping me up at night! Virginia will need to be bumped accordingly but that's still pointing at Adhearsion 2.6 right now and I don't use it at all.