### PR TITLE
refactor Events to a thread-pool executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/adhearsion)
+  * Change: Move events system (once again) from Celluloid to using a thread pool executor (the previous move from GirlFriday to Celluloid has degraded performance considerably under heavy concurrent load)
   * Bugfix: Return correct recording uri for wav49 format with Asterisk.
   * Bugfix: Handle more AMI error responses which mean the channel is not found
   * Bugfix: Reporting statistics should not deadlock call processing

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ruby_jid', ["~> 1.0"]
   s.add_runtime_dependency 'ruby_speech', ["~> 3.0"]
   s.add_runtime_dependency 'state_machine', ["~> 1.0"]
+  s.add_runtime_dependency 'sucker_punch', ["~> 2.0"]
   s.add_runtime_dependency 'thor', "~> 0.18.0"
   s.add_runtime_dependency 'virtus', ["~> 1.0"]
 

--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'adhearsion-loquacious', ["~> 1.9"]
   s.add_runtime_dependency 'blather', ["~> 2.0"]
   s.add_runtime_dependency 'celluloid', ["~> 0.16.0"]
+  s.add_runtime_dependency 'concurrent-ruby', ["~> 1.0"]
   s.add_runtime_dependency 'countdownlatch'
   s.add_runtime_dependency 'deep_merge'
   s.add_runtime_dependency 'ffi', ["~> 1.0"]
@@ -41,7 +42,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ruby_jid', ["~> 1.0"]
   s.add_runtime_dependency 'ruby_speech', ["~> 3.0"]
   s.add_runtime_dependency 'state_machine', ["~> 1.0"]
-  s.add_runtime_dependency 'sucker_punch', ["~> 2.0"]
   s.add_runtime_dependency 'thor', "~> 0.18.0"
   s.add_runtime_dependency 'virtus', ["~> 1.0"]
 

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -5,6 +5,7 @@ abort "ERROR: You are running Adhearsion on an unsupported version of Ruby (Ruby
 %w(
   adhearsion/rayo
   celluloid
+  sucker_punch
   active_support/inflector
 ).each { |r| require r }
 
@@ -120,6 +121,15 @@ module Celluloid
     undef :logger
     def logger
       ::Logging.logger['Celluloid']
+    end
+  end
+end
+
+module SuckerPunch
+  class << self
+    undef :default_logger
+    def default_logger
+      ::Logging.logger['SuckerPunch']
     end
   end
 end

--- a/lib/adhearsion.rb
+++ b/lib/adhearsion.rb
@@ -5,7 +5,6 @@ abort "ERROR: You are running Adhearsion on an unsupported version of Ruby (Ruby
 %w(
   adhearsion/rayo
   celluloid
-  sucker_punch
   active_support/inflector
 ).each { |r| require r }
 
@@ -121,15 +120,6 @@ module Celluloid
     undef :logger
     def logger
       ::Logging.logger['Celluloid']
-    end
-  end
-end
-
-module SuckerPunch
-  class << self
-    undef :default_logger
-    def default_logger
-      ::Logging.logger['SuckerPunch']
     end
   end
 end

--- a/lib/adhearsion/configuration.rb
+++ b/lib/adhearsion/configuration.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'loquacious'
+require 'concurrent'
 
 module Adhearsion
   class Configuration
@@ -50,7 +51,7 @@ module Adhearsion
           Does not work under JRuby.
         __
 
-        event_threads 5, transform: Proc.new { |v| Adhearsion::Configuration.validate_number v }, desc: <<-__
+        event_threads Concurrent.processor_count, transform: Proc.new { |v| Adhearsion::Configuration.validate_number v }, desc: <<-__
           The number of threads to include in the event worker pool."
         __
 


### PR DESCRIPTION
this should be similar to what AHN had in 2.x (using GirlFriday).
and provides much better performance (on JRuby) - resolves #630

(for reference: tried using GirlFriday but its bg job processing assumptions made not such a great fit)

and since we're no longer an actor - the error loop is avoided by design (fixes #633)

NOTE: these changes are performed a top of: https://github.com/adhearsion/adhearsion/pull/632
(which is unfortunate but necessary to have a :heavy_check_mark: CI)