### PR TITLE
[SPEC] relax nio4r constraint for specs

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -53,5 +53,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-yard'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'timecop'
-  s.add_development_dependency 'nio4r', "< 2.4.0"
 end


### PR DESCRIPTION
### relax nio4r constraint for specs

This _just_ became possible since [nio4r-2.4.0 was re-released to include a -java version](https://github.com/socketry/nio4r/issues/213#issuecomment-509446213).

This reverts commit c4b9e9af4ff17f002fef9ce07fbda3115d9d7c06.