### PR TITLE
[CS] Remove unused :hard_shutdown state_machine event

### DIFF
--- a/lib/adhearsion/process.rb
+++ b/lib/adhearsion/process.rb
@@ -39,10 +39,6 @@ module Adhearsion
         transition :booting => :force_stopped
       end
 
-      event :hard_shutdown do
-        transition [:running, :stopping] => :rejecting
-      end
-
       event :stop do
         transition all => :stopped
       end


### PR DESCRIPTION
With its invocation removed in 68caa09137e91da15288e5060a22b9ac225cc725, the hard_shutdown event definition in the state_machine API is no longer trigger-able and is now dead code.  This minor PR simply removes it.