### PR TITLE
[SPEC] Prevent JRuby build of RSpec from getting stuck.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,12 +48,12 @@ RSpec.configure do |config|
 
   config.after :each do
     Timecop.return
-    Adhearsion::Events.clear
     if defined?(:Celluloid)
       Celluloid.shutdown
       Adhearsion.active_calls = nil
       Celluloid.boot
     end
+    Adhearsion::Events.clear
   end
 end
 


### PR DESCRIPTION
Change order of things so that Adhearsion::Events' Executor thread pool is not
re-initialized after being cleared.  What was happening:

1. Adhearsion::Events' Executor thread pool was cleared.
2. Celluloid.shutdown forcefully kills actors, which then triggers several
   exception events
3. #catching_standard_errors invokes `Adhearsion::Events.trigger :exception, [e, l]`, which reinits a new Executor thread pool.  Once the pool is reinitialized, the test suite can't shutdown.

Now, 2. happens before 1... so Celluloid exceptions can have their fit before we
try to shutdown Events.