### PR TITLE
[SPEC] Profile slowest cucumber features

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,3 +29,20 @@ Aruba.configure do |config|
     set_env('JAVA_OPTS', "#{ENV['JAVA_OPTS']} #{JAVA_OPTS_SAVED}")
   end
 end if RUBY_PLATFORM == 'java'
+
+# Profile slowest features
+# @see https://itshouldbeuseful.wordpress.com/2010/11/10/find-your-slowest-running-cucumber-features/
+scenario_times = {}
+Around() do |scenario, block|
+  start = Time.now
+  block.call
+  scenario_times["#{scenario.feature.file}::#{scenario.name}"] = Time.now - start
+end
+at_exit do
+  max_scenarios = scenario_times.size > 30 ? 30 : scenario_times.size
+  puts "------------- Top #{max_scenarios} slowest scenarios -------------"
+  sorted_times = scenario_times.sort { |a, b| b[1] <=> a[1] }
+  sorted_times[0..max_scenarios - 1].each do |key, value|
+    puts "#{value.round(2)}  #{key}"
+  end
+end


### PR DESCRIPTION
Fork-lifted a technique from https://itshouldbeuseful.wordpress.com/2010/11/10/find-your-slowest-running-cucumber-features/ for profiling slow cucumber tests.  Particularly helpful with how slow some of the cucumber tests are running/timing-out on some JRuby builds currently.

Here's an example of the output:

```
------------- Top 22 slowest scenarios -------------
86.15  features/cli_start.feature::Command start with only path works properly
82.52  features/cli_start.feature::Command start with no path inside of the app directory
22.84  features/cli_start.feature::Starting without the console
21.46  features/controller_generator.feature::Generate a controller with lower-case name
21.23  features/controller_generator.feature::Generate a controller and a test file
12.18  features/cli_plugin.feature::Command create_rubygem_hook
10.89  features/cli_plugin.feature::Command create_github_hook
9.9  features/plugin_generator.feature::Generate the basic structure for a plugin with a constant name
8.97  features/cli_create.feature::Generate application with valid layout
8.59  features/cli_create.feature::Generate application --empty
8.58  features/cli_basic.feature::No arguments given
8.53  features/cli_create.feature::Running create with no arguments
8.43  features/plugin_generator.feature::Generate the basic structure for a plugin with an underscored name
8.42  features/cli_generate.feature::Generator help
8.38  features/cli_plugin.feature::No arguments given
8.29  features/cli_basic.feature::Command help
8.28  features/cli_plugin.feature::Command help
8.26  features/cli_generate.feature::Listing generators
8.24  features/cli_basic.feature::Command version should print the version
8.18  features/cli_start.feature::Command start with no path outside of the app directory
8.12  features/cli_plugin.feature::Unrecognized commands
8.08  features/cli_basic.feature::Unrecognized commands
```