### PR TITLE
Add gem version constrants to make tests pass

### DIFF
--- a/adhearsion.gemspec
+++ b/adhearsion.gemspec
@@ -31,11 +31,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'future-resource', ["~> 1.0"]
   s.add_runtime_dependency 'has-guarded-handlers', ["~> 1.6", ">= 1.6.3"]
   s.add_runtime_dependency 'i18n', ["~> 0.6"]
-  s.add_runtime_dependency 'logging', ["~> 2.0"]
-  s.add_runtime_dependency 'nokogiri', ["~> 1.8", ">= 1.8.3"]
+  s.add_runtime_dependency 'logging', ["~> 2.0", "< 2.3"] # See https://github.com/TwP/logging/issues/235
+  s.add_runtime_dependency 'nokogiri', ["~> 1.8", ">= 1.8.3", "< 1.11"] # Versions > 1.10 broken under JRuby
   s.add_runtime_dependency 'pry'
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'reel', ["~> 0.6.0"]
+  s.add_runtime_dependency 'http_parser.rb', ["~> 0.6.0"] # Dependency of Reel, verions > 0.6.0 broken under JRuby
   s.add_runtime_dependency 'reel-rack', ["~> 0.2.0"]
   s.add_runtime_dependency 'ruby_ami', ["~> 2.2"]
   s.add_runtime_dependency 'ruby_jid', ["~> 1.0"]


### PR DESCRIPTION
The gem versions here are capped due to issues found in upstream repos. Lock them for now so Adhearsion users get a reliable experience.